### PR TITLE
Allow multiple transformations per kind

### DIFF
--- a/src/main/php/lang/ast/transform/Transformations.class.php
+++ b/src/main/php/lang/ast/transform/Transformations.class.php
@@ -3,11 +3,39 @@
 class Transformations {
   private static $transformations= [];
 
-  public static function register($type, $function) {
-    self::$transformations[$type]= $function;
+  /**
+   * Registers a transformation
+   *
+   * @param  string $kind
+   * @param  function(lang.ast.Node): lang.ast.Node|iterable $function
+   * @return int
+   */
+  public static function register($kind, $function) {
+    self::$transformations[]= [$kind, $function];
+    return sizeof(self::$transformations) - 1;
   }
 
+  /**
+   * Removes given transformations
+   *
+   * @param  int... $ids Returned by register()
+   * @return void
+   */
+  public static function remove(... $ids) {
+    foreach ($ids as $id) {
+      unset(self::$transformations[$id]);
+    }
+  }
+
+  /**
+   * Returns all registered transformations, the key being the kind
+   * and the value being the transformation function.
+   *
+   * @return iterable
+   */
   public static function registered() {
-    return self::$transformations;
+    foreach (self::$transformations as $transformation) {
+      yield $transformation[0] => $transformation[1];
+    }
   }
 }

--- a/src/test/php/lang/ast/unittest/TransformationsTest.class.php
+++ b/src/test/php/lang/ast/unittest/TransformationsTest.class.php
@@ -1,13 +1,61 @@
 <?php namespace lang\ast\unittest;
 
 use lang\ast\transform\Transformations;
+use unittest\TestCase;
 
-class TransformationsTest extends \unittest\TestCase {
+class TransformationsTest extends TestCase {
+  private $remove= [];
+
+  /**
+   * Registers a transformation; registering it for removal a test shutdown
+   *
+   * @param  string $kind
+   * @param  function(lang.ast.Node): lang.ast.Node|iterable $function
+   * @return void
+   */
+  private function register($kind, $function) {
+    $this->remove[]= Transformations::register($kind, $function);
+  }
+
+  /**
+   * Assertion helper
+   *
+   * @param  [:var][] $expected
+   * @throws unittest.AssertionFailedError
+   */
+  private function assertRegistered($expected) {
+    $actual= [];
+    foreach (Transformations::registered() as $kind => $transformation) {
+      $actual[]= [$kind => $transformation];
+    }
+    $this->assertEquals($expected, $actual);
+  }
+
+  /** @return void */
+  public function tearDown() {
+    Transformations::remove(...$this->remove);
+  }
 
   #[@test]
-  public function register() {
-    Transformations::register('class', function($class) {
-      return $class;
-    });
+  public function registered_initially_empty() {
+    $this->assertRegistered([]);
+  }
+
+  #[@test]
+  public function register_function() {
+    $function= function($class) { return $class; };
+
+    $this->register('class', $function);
+    $this->assertRegistered([['class' => $function]]);
+  }
+
+  #[@test]
+  public function register_two_functions() {
+    $first= function($class) { return $class; };
+    $second= function($class) { $class->annotations['author']= 'Test'; return $class; };
+
+    $this->register('class', $first);
+    $this->register('class', $second);
+    $this->assertRegistered([['class' => $first], ['class' => $second]]);
   }
 }


### PR DESCRIPTION
Previously, the second call would overwrite the first one, and only classes annotated with `setters` would be handled. Now, both transformations are run.

```php
Transformations::register('class', function($class) {
  if ($class->annotation('getters')) { ... }
  return $class;
});
Transformations::register('class', function($class) {
  if ($class->annotation('setters')) { ... }
  return $class;
});
```