### PR TITLE
Add support for match expression

### DIFF
--- a/src/main/php/lang/ast/nodes/MatchCondition.class.php
+++ b/src/main/php/lang/ast/nodes/MatchCondition.class.php
@@ -1,0 +1,26 @@
+<?php namespace lang\ast\nodes;
+
+use lang\ast\Node;
+
+/**
+ * Match condition inside a match expression
+ */
+class MatchCondition extends Node {
+  public $kind= 'condition';
+  public $expressions, $body;
+
+  public function __construct($expressions, $body) {
+    $this->expressions= $expressions;
+    $this->body= $body;
+  }
+
+  /** @return iterable */
+  public function children() {
+    foreach ($this->expressions as $expression) {
+      yield $expression;
+    }
+    foreach ($this->body as $node) {
+      yield $node;
+    }
+  }
+}

--- a/src/main/php/lang/ast/nodes/MatchExpression.class.php
+++ b/src/main/php/lang/ast/nodes/MatchExpression.class.php
@@ -1,0 +1,28 @@
+<?php namespace lang\ast\nodes;
+
+use lang\ast\Node;
+
+/**
+ * Match statement with cases
+ *
+ * @see  https://wiki.php.net/rfc/match_expression_v2
+ * @test xp://lang.ast.unittest.ConditionalTest
+ */
+class MatchExpression extends Node {
+  public $kind= 'match';
+  public $expression, $cases;
+
+  public function __construct($expression, $cases, $line= -1) {
+    $this->expression= $expression;
+    $this->cases= $cases;
+    $this->line= $line;
+  }
+
+  /** @return iterable */
+  public function children() {
+    yield $this->expression;
+    foreach ($this->cases as $element) {
+      yield $element;
+    }
+  }
+}

--- a/src/main/php/lang/ast/nodes/MatchExpression.class.php
+++ b/src/main/php/lang/ast/nodes/MatchExpression.class.php
@@ -10,11 +10,12 @@ use lang\ast\Node;
  */
 class MatchExpression extends Node {
   public $kind= 'match';
-  public $expression, $cases;
+  public $expression, $cases, $default;
 
-  public function __construct($expression, $cases, $line= -1) {
+  public function __construct($expression, $cases, $default, $line= -1) {
     $this->expression= $expression;
     $this->cases= $cases;
+    $this->default= $default;
     $this->line= $line;
   }
 

--- a/src/main/php/lang/ast/syntax/PHP.class.php
+++ b/src/main/php/lang/ast/syntax/PHP.class.php
@@ -469,14 +469,14 @@ class PHP extends Language {
         if ('default' === $parse->token->value) {
           $parse->forward();
           $parse->expecting('=>', 'match');
-          $default= [$this->expression($parse, 0)];
+          $default= $this->expression($parse, 0);
         } else {
           $match= [];
           do {
             $match[]= $this->expression($parse, 0);
           } while (',' === $parse->token->value && $parse->forward() | true);
           $parse->expecting('=>', 'match');
-          $cases[]= new MatchCondition($match, [$this->expression($parse, 0)], $parse->token->line);
+          $cases[]= new MatchCondition($match, $this->expression($parse, 0), $parse->token->line);
         }
 
         if (',' === $parse->token->value) {

--- a/src/main/php/lang/ast/syntax/PHP.class.php
+++ b/src/main/php/lang/ast/syntax/PHP.class.php
@@ -42,6 +42,7 @@ use lang\ast\nodes\{
   SwitchStatement,
   TernaryExpression,
   MatchExpression,
+  MatchCondition,
   ThrowExpression,
   ThrowStatement,
   TraitDeclaration,
@@ -475,7 +476,7 @@ class PHP extends Language {
             $match[]= $this->expression($parse, 0);
           } while (',' === $parse->token->value && $parse->forward() | true);
           $parse->expecting('=>', 'match');
-          $cases[]= new CaseLabel($match, [$this->expression($parse, 0)], $parse->token->line);
+          $cases[]= new MatchCondition($match, [$this->expression($parse, 0)], $parse->token->line);
         }
 
         if (',' === $parse->token->value) {

--- a/src/main/php/lang/ast/syntax/PHP.class.php
+++ b/src/main/php/lang/ast/syntax/PHP.class.php
@@ -464,15 +464,15 @@ class PHP extends Language {
       $cases= [];
       $parse->expecting('{', 'match');
       while ('}' !== $parse->token->value) {
-        $match= [];
-        do {
-          if ('default' === $parse->token->value) {
-            $parse->forward();
-            $match[]= null;
-          } else {
+        if ('default' === $parse->token->value) {
+          $parse->forward();
+          $match= [null];
+        } else {
+          $match= [];
+          do {
             $match[]= $this->expression($parse, 0);
-          }
-        } while (',' === $parse->token->value && $parse->forward() | true);
+          } while (',' === $parse->token->value && $parse->forward() | true);
+        }
 
         $parse->expecting('=>', 'match');
         $cases[]= new CaseLabel($match, [$this->expression($parse, 0)], $parse->token->line);

--- a/src/test/php/lang/ast/unittest/parse/ConditionalTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/ConditionalTest.class.php
@@ -1,6 +1,6 @@
 <?php namespace lang\ast\unittest\parse;
 
-use lang\ast\nodes\{CaseLabel, IfStatement, InvokeExpression, Literal, SwitchStatement, MatchExpression, Variable};
+use lang\ast\nodes\{CaseLabel, IfStatement, InvokeExpression, Literal, SwitchStatement, MatchExpression, MatchCondition, Variable};
 use unittest\Assert;
 
 class ConditionalTest extends ParseTest {
@@ -96,7 +96,7 @@ class ConditionalTest extends ParseTest {
   #[@test]
   public function match_with_trailing_comma() {
     $cases= [
-      new CaseLabel([new Literal('1', self::LINE)], $this->blocks[1], self::LINE),
+      new MatchCondition([new Literal('1', self::LINE)], $this->blocks[1], self::LINE),
     ];
     $this->assertParsed(
       [new MatchExpression(new Variable('condition', self::LINE), $cases, null, self::LINE)],
@@ -107,8 +107,8 @@ class ConditionalTest extends ParseTest {
   #[@test]
   public function match_with_two_cases() {
     $cases= [
-      new CaseLabel([new Literal('1', self::LINE)], $this->blocks[1], self::LINE),
-      new CaseLabel([new Literal('2', self::LINE)], $this->blocks[2], self::LINE)
+      new MatchCondition([new Literal('1', self::LINE)], $this->blocks[1], self::LINE),
+      new MatchCondition([new Literal('2', self::LINE)], $this->blocks[2], self::LINE)
     ];
     $this->assertParsed(
       [new MatchExpression(new Variable('condition', self::LINE), $cases, null, self::LINE)],
@@ -119,7 +119,7 @@ class ConditionalTest extends ParseTest {
   #[@test]
   public function match_with_multi_expression_case_and_default() {
     $cases= [
-      new CaseLabel([new Literal('1', self::LINE), new Literal('2', self::LINE)], $this->blocks[1], self::LINE),
+      new MatchCondition([new Literal('1', self::LINE), new Literal('2', self::LINE)], $this->blocks[1], self::LINE),
     ];
     $this->assertParsed(
       [new MatchExpression(new Variable('condition', self::LINE), $cases, $this->blocks[2], self::LINE)],

--- a/src/test/php/lang/ast/unittest/parse/ConditionalTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/ConditionalTest.class.php
@@ -88,7 +88,7 @@ class ConditionalTest extends ParseTest {
   #[@test]
   public function empty_match() {
     $this->assertParsed(
-      [new MatchExpression(new Variable('condition', self::LINE), [], self::LINE)],
+      [new MatchExpression(new Variable('condition', self::LINE), [], null, self::LINE)],
       'match ($condition) { };'
     );
   }
@@ -99,7 +99,7 @@ class ConditionalTest extends ParseTest {
       new CaseLabel([new Literal('1', self::LINE)], $this->blocks[1], self::LINE),
     ];
     $this->assertParsed(
-      [new MatchExpression(new Variable('condition', self::LINE), $cases, self::LINE)],
+      [new MatchExpression(new Variable('condition', self::LINE), $cases, null, self::LINE)],
       'match ($condition) { 1 => action1(), };'
     );
   }
@@ -111,7 +111,7 @@ class ConditionalTest extends ParseTest {
       new CaseLabel([new Literal('2', self::LINE)], $this->blocks[2], self::LINE)
     ];
     $this->assertParsed(
-      [new MatchExpression(new Variable('condition', self::LINE), $cases, self::LINE)],
+      [new MatchExpression(new Variable('condition', self::LINE), $cases, null, self::LINE)],
       'match ($condition) { 1 => action1(), 2 => action2() };'
     );
   }
@@ -120,10 +120,9 @@ class ConditionalTest extends ParseTest {
   public function match_with_multi_expression_case_and_default() {
     $cases= [
       new CaseLabel([new Literal('1', self::LINE), new Literal('2', self::LINE)], $this->blocks[1], self::LINE),
-      new CaseLabel([null], $this->blocks[2], self::LINE)
     ];
     $this->assertParsed(
-      [new MatchExpression(new Variable('condition', self::LINE), $cases, self::LINE)],
+      [new MatchExpression(new Variable('condition', self::LINE), $cases, $this->blocks[2], self::LINE)],
       'match ($condition) { 1, 2 => action1(), default => action2() };'
     );
   }

--- a/src/test/php/lang/ast/unittest/parse/ConditionalTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/ConditionalTest.class.php
@@ -10,15 +10,15 @@ class ConditionalTest extends ParseTest {
   #[@before]
   public function setUp() {
     $this->blocks= [
-      1 => new InvokeExpression(new Literal('action1', self::LINE), [], self::LINE),
-      2 => new InvokeExpression(new Literal('action2', self::LINE), [], self::LINE)
+      1 => [new InvokeExpression(new Literal('action1', self::LINE), [], self::LINE)],
+      2 => [new InvokeExpression(new Literal('action2', self::LINE), [], self::LINE)]
     ];
   }
 
   #[@test]
   public function plain_if() {
     $this->assertParsed(
-      [new IfStatement(new Variable('condition', self::LINE), [$this->blocks[1]], null, self::LINE)],
+      [new IfStatement(new Variable('condition', self::LINE), $this->blocks[1], null, self::LINE)],
       'if ($condition) { action1(); }'
     );
   }
@@ -26,7 +26,7 @@ class ConditionalTest extends ParseTest {
   #[@test]
   public function if_with_else() {
     $this->assertParsed(
-      [new IfStatement(new Variable('condition', self::LINE), [$this->blocks[1]], [$this->blocks[2]], self::LINE)],
+      [new IfStatement(new Variable('condition', self::LINE), $this->blocks[1], $this->blocks[2], self::LINE)],
       'if ($condition) { action1(); } else { action2(); }'
     );
   }
@@ -34,7 +34,7 @@ class ConditionalTest extends ParseTest {
   #[@test]
   public function shortcut_if() {
     $this->assertParsed(
-      [new IfStatement(new Variable('condition', self::LINE), [$this->blocks[1]], null, self::LINE)],
+      [new IfStatement(new Variable('condition', self::LINE), $this->blocks[1], null, self::LINE)],
       'if ($condition) action1();'
     );
   }
@@ -42,7 +42,7 @@ class ConditionalTest extends ParseTest {
   #[@test]
   public function shortcut_if_else() {
     $this->assertParsed(
-      [new IfStatement(new Variable('condition', self::LINE), [$this->blocks[1]], [$this->blocks[2]], self::LINE)],
+      [new IfStatement(new Variable('condition', self::LINE), $this->blocks[1], $this->blocks[2], self::LINE)],
       'if ($condition) action1(); else action2();'
     );
   }
@@ -57,7 +57,7 @@ class ConditionalTest extends ParseTest {
 
   #[@test]
   public function switch_with_one_case() {
-    $cases= [new CaseLabel(new Literal('1', self::LINE), [$this->blocks[1]], self::LINE)];
+    $cases= [new CaseLabel(new Literal('1', self::LINE), $this->blocks[1], self::LINE)];
     $this->assertParsed(
       [new SwitchStatement(new Variable('condition', self::LINE), $cases, self::LINE)],
       'switch ($condition) { case 1: action1(); }'
@@ -67,8 +67,8 @@ class ConditionalTest extends ParseTest {
   #[@test]
   public function switch_with_two_cases() {
     $cases= [
-      new CaseLabel(new Literal('1', self::LINE), [$this->blocks[1]], self::LINE),
-      new CaseLabel(new Literal('2', self::LINE), [$this->blocks[2]], self::LINE)
+      new CaseLabel(new Literal('1', self::LINE), $this->blocks[1], self::LINE),
+      new CaseLabel(new Literal('2', self::LINE), $this->blocks[2], self::LINE)
     ];
     $this->assertParsed(
       [new SwitchStatement(new Variable('condition', self::LINE), $cases, self::LINE)],
@@ -78,7 +78,7 @@ class ConditionalTest extends ParseTest {
 
   #[@test]
   public function switch_with_default() {
-    $cases= [new CaseLabel(null, [$this->blocks[1]], self::LINE)];
+    $cases= [new CaseLabel(null, $this->blocks[1], self::LINE)];
     $this->assertParsed(
       [new SwitchStatement(new Variable('condition', self::LINE), $cases, self::LINE)],
       'switch ($condition) { default: action1(); }'
@@ -96,7 +96,7 @@ class ConditionalTest extends ParseTest {
   #[@test]
   public function match_with_trailing_comma() {
     $cases= [
-      new CaseLabel([new Literal('1', self::LINE)], [$this->blocks[1]], self::LINE),
+      new CaseLabel([new Literal('1', self::LINE)], $this->blocks[1], self::LINE),
     ];
     $this->assertParsed(
       [new MatchExpression(new Variable('condition', self::LINE), $cases, self::LINE)],
@@ -107,8 +107,8 @@ class ConditionalTest extends ParseTest {
   #[@test]
   public function match_with_two_cases() {
     $cases= [
-      new CaseLabel([new Literal('1', self::LINE)], [$this->blocks[1]], self::LINE),
-      new CaseLabel([new Literal('2', self::LINE)], [$this->blocks[2]], self::LINE)
+      new CaseLabel([new Literal('1', self::LINE)], $this->blocks[1], self::LINE),
+      new CaseLabel([new Literal('2', self::LINE)], $this->blocks[2], self::LINE)
     ];
     $this->assertParsed(
       [new MatchExpression(new Variable('condition', self::LINE), $cases, self::LINE)],
@@ -119,7 +119,7 @@ class ConditionalTest extends ParseTest {
   #[@test]
   public function match_with_multi_expression_case() {
     $cases= [
-      new CaseLabel([new Literal('1', self::LINE), new Literal('2', self::LINE)], [$this->blocks[1]], self::LINE),
+      new CaseLabel([new Literal('1', self::LINE), new Literal('2', self::LINE)], $this->blocks[1], self::LINE),
     ];
     $this->assertParsed(
       [new MatchExpression(new Variable('condition', self::LINE), $cases, self::LINE)],
@@ -129,7 +129,7 @@ class ConditionalTest extends ParseTest {
 
   #[@test]
   public function match_with_default() {
-    $cases= [new CaseLabel([null], [$this->blocks[1]], self::LINE)];
+    $cases= [new CaseLabel([null], $this->blocks[1], self::LINE)];
     $this->assertParsed(
       [new MatchExpression(new Variable('condition', self::LINE), $cases, self::LINE)],
       'match ($condition) { default => action1() };'

--- a/src/test/php/lang/ast/unittest/parse/ConditionalTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/ConditionalTest.class.php
@@ -96,7 +96,7 @@ class ConditionalTest extends ParseTest {
   #[@test]
   public function match_with_trailing_comma() {
     $cases= [
-      new MatchCondition([new Literal('1', self::LINE)], $this->blocks[1], self::LINE),
+      new MatchCondition([new Literal('1', self::LINE)], $this->blocks[1][0], self::LINE),
     ];
     $this->assertParsed(
       [new MatchExpression(new Variable('condition', self::LINE), $cases, null, self::LINE)],
@@ -107,8 +107,8 @@ class ConditionalTest extends ParseTest {
   #[@test]
   public function match_with_two_cases() {
     $cases= [
-      new MatchCondition([new Literal('1', self::LINE)], $this->blocks[1], self::LINE),
-      new MatchCondition([new Literal('2', self::LINE)], $this->blocks[2], self::LINE)
+      new MatchCondition([new Literal('1', self::LINE)], $this->blocks[1][0], self::LINE),
+      new MatchCondition([new Literal('2', self::LINE)], $this->blocks[2][0], self::LINE)
     ];
     $this->assertParsed(
       [new MatchExpression(new Variable('condition', self::LINE), $cases, null, self::LINE)],
@@ -119,10 +119,10 @@ class ConditionalTest extends ParseTest {
   #[@test]
   public function match_with_multi_expression_case_and_default() {
     $cases= [
-      new MatchCondition([new Literal('1', self::LINE), new Literal('2', self::LINE)], $this->blocks[1], self::LINE),
+      new MatchCondition([new Literal('1', self::LINE), new Literal('2', self::LINE)], $this->blocks[1][0], self::LINE),
     ];
     $this->assertParsed(
-      [new MatchExpression(new Variable('condition', self::LINE), $cases, $this->blocks[2], self::LINE)],
+      [new MatchExpression(new Variable('condition', self::LINE), $cases, $this->blocks[2][0], self::LINE)],
       'match ($condition) { 1, 2 => action1(), default => action2() };'
     );
   }

--- a/src/test/php/lang/ast/unittest/parse/ConditionalTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/ConditionalTest.class.php
@@ -117,22 +117,14 @@ class ConditionalTest extends ParseTest {
   }
 
   #[@test]
-  public function match_with_multi_expression_case() {
+  public function match_with_multi_expression_case_and_default() {
     $cases= [
       new CaseLabel([new Literal('1', self::LINE), new Literal('2', self::LINE)], $this->blocks[1], self::LINE),
+      new CaseLabel([null], $this->blocks[2], self::LINE)
     ];
     $this->assertParsed(
       [new MatchExpression(new Variable('condition', self::LINE), $cases, self::LINE)],
-      'match ($condition) { 1, 2 => action1() };'
-    );
-  }
-
-  #[@test]
-  public function match_with_default() {
-    $cases= [new CaseLabel([null], $this->blocks[1], self::LINE)];
-    $this->assertParsed(
-      [new MatchExpression(new Variable('condition', self::LINE), $cases, self::LINE)],
-      'match ($condition) { default => action1() };'
+      'match ($condition) { 1, 2 => action1(), default => action2() };'
     );
   }
 }

--- a/src/test/php/lang/ast/unittest/parse/ConditionalTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/ConditionalTest.class.php
@@ -1,6 +1,6 @@
 <?php namespace lang\ast\unittest\parse;
 
-use lang\ast\nodes\{CaseLabel, IfStatement, InvokeExpression, Literal, SwitchStatement, Variable};
+use lang\ast\nodes\{CaseLabel, IfStatement, InvokeExpression, Literal, SwitchStatement, MatchExpression, Variable};
 use unittest\Assert;
 
 class ConditionalTest extends ParseTest {
@@ -10,15 +10,15 @@ class ConditionalTest extends ParseTest {
   #[@before]
   public function setUp() {
     $this->blocks= [
-      1 => [new InvokeExpression(new Literal('action1', self::LINE), [], self::LINE)],
-      2 => [new InvokeExpression(new Literal('action2', self::LINE), [], self::LINE)]
+      1 => new InvokeExpression(new Literal('action1', self::LINE), [], self::LINE),
+      2 => new InvokeExpression(new Literal('action2', self::LINE), [], self::LINE)
     ];
   }
 
   #[@test]
   public function plain_if() {
     $this->assertParsed(
-      [new IfStatement(new Variable('condition', self::LINE), $this->blocks[1], null, self::LINE)],
+      [new IfStatement(new Variable('condition', self::LINE), [$this->blocks[1]], null, self::LINE)],
       'if ($condition) { action1(); }'
     );
   }
@@ -26,7 +26,7 @@ class ConditionalTest extends ParseTest {
   #[@test]
   public function if_with_else() {
     $this->assertParsed(
-      [new IfStatement(new Variable('condition', self::LINE), $this->blocks[1], $this->blocks[2], self::LINE)],
+      [new IfStatement(new Variable('condition', self::LINE), [$this->blocks[1]], [$this->blocks[2]], self::LINE)],
       'if ($condition) { action1(); } else { action2(); }'
     );
   }
@@ -34,7 +34,7 @@ class ConditionalTest extends ParseTest {
   #[@test]
   public function shortcut_if() {
     $this->assertParsed(
-      [new IfStatement(new Variable('condition', self::LINE), $this->blocks[1], null, self::LINE)],
+      [new IfStatement(new Variable('condition', self::LINE), [$this->blocks[1]], null, self::LINE)],
       'if ($condition) action1();'
     );
   }
@@ -42,7 +42,7 @@ class ConditionalTest extends ParseTest {
   #[@test]
   public function shortcut_if_else() {
     $this->assertParsed(
-      [new IfStatement(new Variable('condition', self::LINE), $this->blocks[1], $this->blocks[2], self::LINE)],
+      [new IfStatement(new Variable('condition', self::LINE), [$this->blocks[1]], [$this->blocks[2]], self::LINE)],
       'if ($condition) action1(); else action2();'
     );
   }
@@ -57,7 +57,7 @@ class ConditionalTest extends ParseTest {
 
   #[@test]
   public function switch_with_one_case() {
-    $cases= [new CaseLabel(new Literal('1', self::LINE), $this->blocks[1], self::LINE)];
+    $cases= [new CaseLabel(new Literal('1', self::LINE), [$this->blocks[1]], self::LINE)];
     $this->assertParsed(
       [new SwitchStatement(new Variable('condition', self::LINE), $cases, self::LINE)],
       'switch ($condition) { case 1: action1(); }'
@@ -67,8 +67,8 @@ class ConditionalTest extends ParseTest {
   #[@test]
   public function switch_with_two_cases() {
     $cases= [
-      new CaseLabel(new Literal('1', self::LINE), $this->blocks[1], self::LINE),
-      new CaseLabel(new Literal('2', self::LINE), $this->blocks[2], self::LINE)
+      new CaseLabel(new Literal('1', self::LINE), [$this->blocks[1]], self::LINE),
+      new CaseLabel(new Literal('2', self::LINE), [$this->blocks[2]], self::LINE)
     ];
     $this->assertParsed(
       [new SwitchStatement(new Variable('condition', self::LINE), $cases, self::LINE)],
@@ -78,10 +78,61 @@ class ConditionalTest extends ParseTest {
 
   #[@test]
   public function switch_with_default() {
-    $cases= [new CaseLabel(null, $this->blocks[1], self::LINE)];
+    $cases= [new CaseLabel(null, [$this->blocks[1]], self::LINE)];
     $this->assertParsed(
       [new SwitchStatement(new Variable('condition', self::LINE), $cases, self::LINE)],
       'switch ($condition) { default: action1(); }'
+    );
+  }
+
+  #[@test]
+  public function empty_match() {
+    $this->assertParsed(
+      [new MatchExpression(new Variable('condition', self::LINE), [], self::LINE)],
+      'match ($condition) { };'
+    );
+  }
+
+  #[@test]
+  public function match_with_trailing_comma() {
+    $cases= [
+      new CaseLabel([new Literal('1', self::LINE)], [$this->blocks[1]], self::LINE),
+    ];
+    $this->assertParsed(
+      [new MatchExpression(new Variable('condition', self::LINE), $cases, self::LINE)],
+      'match ($condition) { 1 => action1(), };'
+    );
+  }
+
+  #[@test]
+  public function match_with_two_cases() {
+    $cases= [
+      new CaseLabel([new Literal('1', self::LINE)], [$this->blocks[1]], self::LINE),
+      new CaseLabel([new Literal('2', self::LINE)], [$this->blocks[2]], self::LINE)
+    ];
+    $this->assertParsed(
+      [new MatchExpression(new Variable('condition', self::LINE), $cases, self::LINE)],
+      'match ($condition) { 1 => action1(), 2 => action2() };'
+    );
+  }
+
+  #[@test]
+  public function match_with_multi_expression_case() {
+    $cases= [
+      new CaseLabel([new Literal('1', self::LINE), new Literal('2', self::LINE)], [$this->blocks[1]], self::LINE),
+    ];
+    $this->assertParsed(
+      [new MatchExpression(new Variable('condition', self::LINE), $cases, self::LINE)],
+      'match ($condition) { 1, 2 => action1() };'
+    );
+  }
+
+  #[@test]
+  public function match_with_default() {
+    $cases= [new CaseLabel([null], [$this->blocks[1]], self::LINE)];
+    $this->assertParsed(
+      [new MatchExpression(new Variable('condition', self::LINE), $cases, self::LINE)],
+      'match ($condition) { default => action1() };'
     );
   }
 }


### PR DESCRIPTION
See https://wiki.php.net/rfc/match_expression_v2 and php/php-src#5371

```php
$statement= match ($this->lexer->lookahead['type']) {
  Lexer::T_SELECT => $this->selectStatement(),
  Lexer::T_UPDATE => $this->updateStatement(),
  Lexer::T_DELETE => $this->deleteStatement(),
  default => $this->syntaxError('SELECT, UPDATE or DELETE'),
};
```

This will produce a `lang.ast.nodes.MatchExpression` node with cases using `lang.ast.nodes.MatchCondition` and a default expression.