### PR TITLE
Fix PHP 8 native syntax

### DIFF
--- a/src/main/php/lang/ast/Tokens.class.php
+++ b/src/main/php/lang/ast/Tokens.class.php
@@ -123,14 +123,19 @@ class Tokens implements \IteratorAggregate {
           do {
             $s= strspn($next, ' ');
             if ('#' !== $next[$s]) break;
-            $line++;
             $comment.= substr($next, $s + 1);
             $next= $this->tokens->nextToken("\r\n").$this->tokens->nextToken("\r\n");
           } while ($this->tokens->hasMoreTokens());
+
+          // XP annotations vs. PHP 8 attributes
           if (0 === strncmp($comment, '[@', 2)) {
+            $this->tokens->pushBack(substr($comment, 1).$next);
+            yield 'operator' => ['#[@', $line];
+          } else if ('[' === $comment[0]) {
             $this->tokens->pushBack(substr($comment, 1).$next);
             yield 'operator' => ['#[', $line];
           } else {
+            $line+= substr_count($comment, "\n");
             $this->tokens->pushBack($next);
           }
           continue;

--- a/src/main/php/lang/ast/syntax/PHP.class.php
+++ b/src/main/php/lang/ast/syntax/PHP.class.php
@@ -979,6 +979,7 @@ class PHP extends Language {
         $parse->expecting(';', 'method declaration');
       } else {
         $parse->expecting('{ or ;', 'method declaration');
+        return;
       }
 
       $body[$lookup]= new Method(

--- a/src/main/php/lang/ast/syntax/PHP.class.php
+++ b/src/main/php/lang/ast/syntax/PHP.class.php
@@ -315,7 +315,7 @@ class PHP extends Language {
         $annotations= [];
         $type= null;
         $parse->forward();
-      } else if ('@@' === $parse->token->value) {
+      } else if ('#[' === $parse->token->value) {
         $parse->forward();
         $annotations= $this->attributes($parse, 'anonymous class annotations');
         $parse->expecting('class', 'anonymous class annotations');
@@ -359,7 +359,7 @@ class PHP extends Language {
       return new UnpackExpression($this->expression($parse, 0), $token->line);
     });
 
-    $this->prefix('@@', 0, function($parse, $token) {
+    $this->prefix('#[', 0, function($parse, $token) {
       $annotations= $this->attributes($parse, 'annotations');
       $expression= $this->expression($parse, 0);
       $expression->annotations= $annotations;
@@ -794,14 +794,14 @@ class PHP extends Language {
       return $type;
     });
 
-    $this->stmt('@@', function($parse, $token) {
+    $this->stmt('#[', function($parse, $token) {
       $annotations= $this->attributes($parse, 'annotations');
       $type= $this->statement($parse);
       $type->annotations= $annotations;
       return $type;
     });
 
-    $this->stmt('#[', function($parse, $token) {
+    $this->stmt('#[@', function($parse, $token) {
       $annotations= $this->meta($parse, 'annotations')[DETAIL_ANNOTATIONS];
       $type= $this->statement($parse);
       $type->annotations= $annotations;
@@ -1121,26 +1121,6 @@ class PHP extends Language {
     $parse->expecting(';', 'field declaration');
   }
 
-  /** Parses PHP8-style attributes (@@test) */
-  public function attributes($parse, $context) {
-    $annotations= [];
-    do {
-      $name= ltrim($parse->scope->resolve($parse->token->value), '\\');
-      $parse->forward();
-
-      if ('(' === $parse->token->value) {
-        $parse->expecting('(', 'annotations');
-        $arguments= $this->expressions($parse);
-        $parse->expecting(')', 'annotations');
-      } else {
-        $arguments= [];
-      }
-      $annotations[$name]= $arguments;
-    } while ('@@' === $parse->token->value && $parse->forward() | true);
-
-    return $annotations;
-  }
-
   /** Parses Hacklang-style annotations (<<test>>) */
   private function annotations($parse, $context) {
     $annotations= [];
@@ -1173,6 +1153,37 @@ class PHP extends Language {
     } while (null !== $parse->token->value);
 
     return $annotations;
+  }
+
+  /** Parses PHP 8 attributes (#[Test]) */
+  private function attributes($parse, $context) {
+    $attributes= [];
+
+    do {
+      $name= ltrim($parse->scope->resolve($parse->token->value), '\\');
+      $parse->forward();
+
+      if ('(' === $parse->token->value) {
+        $parse->expecting('(', $context);
+        $attributes[$name]= $this->expressions($parse);
+        $parse->expecting(')', $context);
+      } else {
+        $attributes[$name]= [];
+      }
+
+      if (',' === $parse->token->value) {
+        $parse->forward();
+        continue;
+      } else if (']' === $parse->token->value) {
+        $parse->forward();
+        break;
+      } else {
+        $parse->expecting(', or ]', $context);
+        break;
+      }
+    } while (null !== $parse->token->value);
+
+    return $attributes;
   }
 
   /** Parses XP-style annotations (#[@test]) */
@@ -1252,7 +1263,7 @@ class PHP extends Language {
 
     $parameters= [];
     while (')' !== $parse->token->value) {
-      if ('@@' === $parse->token->value) {
+      if ('#[' === $parse->token->value) {
         $parse->forward();
         $annotations= $this->attributes($parse, 'parameter annotations');
       } else if ('<<' === $parse->token->value) {
@@ -1338,15 +1349,15 @@ class PHP extends Language {
         $f($parse, $body, $meta, $modifiers, $holder);
         $modifiers= [];
         $meta= [];
-      } else if ('@@' === $parse->token->value) {
+      } else if ('#[' === $parse->token->value) {
         $parse->forward();
         $meta= [DETAIL_ANNOTATIONS => $this->attributes($parse, 'member annotations')];
+      } else if ('#[@' === $parse->token->value) {
+        $parse->forward();
+        $meta= $this->meta($parse, 'member annotations');
       } else if ('<<' === $parse->token->value) {
         $parse->forward();
         $meta= [DETAIL_ANNOTATIONS => $this->annotations($parse, 'member annotations')];
-      } else if ('#[' === $parse->token->value) {
-        $parse->forward();
-        $meta= $this->meta($parse, 'member annotations');
       } else if ($type= $this->type($parse)) {
         $this->properties($parse, $body, $meta, $modifiers, $type, $holder);
         $modifiers= [];

--- a/src/test/php/lang/ast/unittest/parse/AttributesTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/AttributesTest.class.php
@@ -102,6 +102,15 @@ class AttributesTest extends ParseTest {
   }
 
   #[@test]
+  public function after_oneline_comment() {
+    $this->assertAnnotated(['Service' => []], $this->type('
+      # Comment
+      #[Service]
+      class T { }
+    '));
+  }
+
+  #[@test]
   public function with_two_arguments() {
     $this->assertAnnotated(
       ['Service' => [new Literal('1', self::LINE), new Literal('2', self::LINE)]],

--- a/src/test/php/lang/ast/unittest/parse/AttributesTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/AttributesTest.class.php
@@ -3,6 +3,7 @@
 use lang\ast\nodes\{Annotated, Literal, ArrayLiteral};
 use unittest\Assert;
 
+/** @see https://wiki.php.net/rfc/shorter_attribute_syntax_change */
 class AttributesTest extends ParseTest {
 
   /**
@@ -21,8 +22,8 @@ class AttributesTest extends ParseTest {
    * @return iterable
    */
   private function attributes() {
-    yield ['@@Service', ['Service' => []]];
-    yield ['@@Service @@Version(1)', ['Service' => [], 'Version' => [new Literal('1', self::LINE)]]];
+    yield ['#[Service]', ['Service' => []]];
+    yield ['#[Service, Version(1)]', ['Service' => [], 'Version' => [new Literal('1', self::LINE)]]];
   }
 
   /**
@@ -41,7 +42,15 @@ class AttributesTest extends ParseTest {
   public function without_arguments() {
     $this->assertAnnotated(
       ['Service' => []],
-      $this->type('@@Service() class T { }')
+      $this->type('#[Service] class T { }')
+    );
+  }
+
+  #[@test]
+  public function with_empty_arguments() {
+    $this->assertAnnotated(
+      ['Service' => []],
+      $this->type('#[Service()] class T { }')
     );
   }
 
@@ -49,7 +58,7 @@ class AttributesTest extends ParseTest {
   public function with_literal_argument($value) {
     $this->assertAnnotated(
       ['Service' => [new Literal($value, self::LINE)]],
-      $this->type('@@Service('.$value.') class T { }')
+      $this->type('#[Service('.$value.')] class T { }')
     );
   }
 
@@ -61,7 +70,7 @@ class AttributesTest extends ParseTest {
     ];
     $this->assertAnnotated(
       ['Service' => [new ArrayLiteral($elements, self::LINE)]],
-      $this->type('@@Service([1, 2]) class T { }')
+      $this->type('#[Service([1, 2])] class T { }')
     );
   }
 
@@ -73,7 +82,7 @@ class AttributesTest extends ParseTest {
     ];
     $this->assertAnnotated(
       ['Service' => [new ArrayLiteral($elements, self::LINE)]],
-      $this->type('@@Service(["one" => 1, "two" => 2]) class T { }')
+      $this->type('#[Service(["one" => 1, "two" => 2])] class T { }')
     );
   }
 
@@ -81,7 +90,7 @@ class AttributesTest extends ParseTest {
   public function with_two_arguments() {
     $this->assertAnnotated(
       ['Service' => [new Literal('1', self::LINE), new Literal('2', self::LINE)]],
-      $this->type('@@Service(1, 2) class T { }')
+      $this->type('#[Service(1, 2)] class T { }')
     );
   }
 
@@ -89,7 +98,7 @@ class AttributesTest extends ParseTest {
   public function two_annotations() {
     $this->assertAnnotated(
       ['Author' => [new Literal('"Test"', self::LINE)], 'Version' => [new Literal('2', self::LINE)]],
-      $this->type('@@Author("Test") @@Version(2) class T { }')
+      $this->type('#[Author("Test"), Version(2)] class T { }')
     );
   }
 
@@ -97,7 +106,7 @@ class AttributesTest extends ParseTest {
   public function name_resolved_to_namespace() {
     $this->assertAnnotated(
       ['example\\Test' => []],
-      $this->parse('namespace example; @@Test class T { }')->tree()->type('example\\T')
+      $this->parse('namespace example; #[Test] class T { }')->tree()->type('example\\T')
     );
   }
 
@@ -105,7 +114,7 @@ class AttributesTest extends ParseTest {
   public function name_resolved_to_import() {
     $this->assertAnnotated(
       ['unittest\\Test' => []],
-      $this->parse('namespace example; use unittest\Test; @@Test class T { }')->tree()->type('example\\T')
+      $this->parse('namespace example; use unittest\Test; #[Test] class T { }')->tree()->type('example\\T')
     );
   }
 
@@ -113,7 +122,7 @@ class AttributesTest extends ParseTest {
   public function name_resolved_to_import_alias() {
     $this->assertAnnotated(
       ['unittest\\TestAttribute' => []],
-      $this->parse('use unittest\TestAttribute as Test; @@Test class T { }')->tree()->type('T')
+      $this->parse('use unittest\TestAttribute as Test; #[Test] class T { }')->tree()->type('T')
     );
   }
 

--- a/src/test/php/lang/ast/unittest/parse/AttributesTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/AttributesTest.class.php
@@ -87,6 +87,21 @@ class AttributesTest extends ParseTest {
   }
 
   #[@test]
+  public function multiline() {
+    $elements= [
+      [new Literal('"one"', self::LINE + 2), new Literal('1', self::LINE + 2)],
+      [new Literal('"two"', self::LINE + 3), new Literal('2', self::LINE + 3)],
+    ];
+    $this->assertAnnotated(['Values' => [new ArrayLiteral($elements, self::LINE + 1)]], $this->type('
+      #[Values([
+        "one" => 1,
+        "two" => 2,
+      ])]
+      class T { }
+    '));
+  }
+
+  #[@test]
   public function with_two_arguments() {
     $this->assertAnnotated(
       ['Service' => [new Literal('1', self::LINE), new Literal('2', self::LINE)]],

--- a/src/test/php/lang/ast/unittest/parse/HackAnnotationsTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/HackAnnotationsTest.class.php
@@ -3,7 +3,7 @@
 use lang\ast\nodes\{Annotated, Literal, ArrayLiteral};
 use unittest\Assert;
 
-class AnnotationTest extends ParseTest {
+class HackAnnotationsTest extends ParseTest {
 
   /**
    * Assertion helper

--- a/src/test/php/lang/ast/unittest/parse/XpAnnotationsTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/XpAnnotationsTest.class.php
@@ -31,7 +31,8 @@ class XpAnnotationsTest extends ParseTest {
   #[@test]
   public function without_arguments() {
     $this->assertAnnotated(['service' => []], $this->type('
-      #[@service] class T { }
+      #[@service]
+      class T { }
     '));
   }
 

--- a/src/test/php/lang/ast/unittest/parse/XpAnnotationsTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/XpAnnotationsTest.class.php
@@ -1,0 +1,143 @@
+<?php namespace lang\ast\unittest\parse;
+
+use lang\ast\nodes\{Annotated, Literal, ArrayLiteral};
+use unittest\Assert;
+
+/** @see https://github.com/xp-framework/rfc/issues/16 */
+class XpAnnotationsTest extends ParseTest {
+
+  /**
+   * Parses source into type
+   *
+   * @param  string $source
+   * @return lang.ast.TypeDeclaration
+   */
+  private function type($source) {
+    return $this->parse(trim($source))->tree()->type('T');
+  }
+
+  /**
+   * Assertion helper
+   *
+   * @param  var $expected
+   * @param  lang.ast.Node $node
+   * @throws unittest.AssertionFailedError
+   * @return void
+   */
+  private function assertAnnotated($expected, $node) {
+    Assert::equals($expected, cast($node, Annotated::class)->annotations);
+  }
+
+  #[@test]
+  public function without_arguments() {
+    $this->assertAnnotated(['service' => []], $this->type('
+      #[@service] class T { }
+    '));
+  }
+
+  #[@test, @values(['"test"', '1', '1.5', 'true', 'false', 'null'])]
+  public function with_literal_argument($value) {
+    $this->assertAnnotated(['service' => [new Literal($value, self::LINE)]], $this->type('
+      #[@service('.$value.')]
+      class T { }
+    '));
+  }
+
+  #[@test]
+  public function with_array_argument() {
+    $elements= [
+      [null, new Literal('1', self::LINE)],
+      [null, new Literal('2', self::LINE)],
+    ];
+    $this->assertAnnotated(['service' => [new ArrayLiteral($elements, self::LINE)]], $this->type('
+      #[@service([1, 2])]
+      class T { }
+    '));
+  }
+
+  #[@test]
+  public function with_map_argument() {
+    $elements= [
+      [new Literal('"one"', self::LINE), new Literal('1', self::LINE)],
+      [new Literal('"two"', self::LINE), new Literal('2', self::LINE)],
+    ];
+    $this->assertAnnotated(['service' => [new ArrayLiteral($elements, self::LINE)]], $this->type('
+      #[@service(["one" => 1, "two" => 2])]
+      class T { }'
+    ));
+  }
+
+  #[@test]
+  public function multiline() {
+    $elements= [
+      [new Literal('"one"', self::LINE + 1), new Literal('1', self::LINE + 1)],
+      [new Literal('"two"', self::LINE + 2), new Literal('2', self::LINE + 2)],
+    ];
+    $this->assertAnnotated(['values' => [new ArrayLiteral($elements, self::LINE)]], $this->type('
+      #[@values([
+      #  "one" => 1,
+      #  "two" => 2,
+      #])]
+      class T { }
+    '));
+  }
+
+  #[@test]
+  public function two_annotations() {
+    $this->assertAnnotated(['service' => [], 'version' => [new Literal('2', self::LINE)]], $this->type('
+      #[@service, @version(2)]
+      class T { }
+    '));
+  }
+
+  #[@test]
+  public function on_class() {
+    $this->assertAnnotated(['service' => []], $this->type('
+      #[@service]
+      class T { }
+    '));
+  }
+
+  #[@test]
+  public function on_trait() {
+    $this->assertAnnotated(['service' => []], $this->type(
+      '#[@service]
+      trait T { }
+    '));
+  }
+
+  #[@test]
+  public function on_interface() {
+    $this->assertAnnotated(['service' => []], $this->type(
+      '#[@service]
+      interface T { }
+    '));
+  }
+
+  #[@test]
+  public function on_property() {
+    $type= $this->type('class T {
+      #[@service]
+      public $fixture;
+    }');
+    $this->assertAnnotated(['service' => []], $type->property('fixture'));
+  }
+
+  #[@test]
+  public function on_method() {
+    $type= $this->type('class T {
+      #[@service]
+      public function fixture() { }
+    }');
+    $this->assertAnnotated(['service' => []], $type->method('fixture'));
+  }
+
+  #[@test]
+  public function on_parameter() {
+    $type= $this->type('class T {
+      #[@$arg: service]
+      public function fixture($arg) { }
+    }');
+    $this->assertAnnotated(['service' => []], $type->method('fixture')->signature->parameters[0]);
+  }
+}


### PR DESCRIPTION
PHP 8 changed its syntax from `@@...` to `#[...]`, see https://wiki.php.net/rfc/shorter_attribute_syntax_change. This pull request fixes the syntax used.