### PR TITLE
Yield comments from tokenizer

### DIFF
--- a/src/main/php/lang/ast/Parse.class.php
+++ b/src/main/php/lang/ast/Parse.class.php
@@ -76,8 +76,10 @@ class Parse {
       } else if ('variable' === $type) {
         $t= new Token($this->language->symbol('(variable)'));
         $t->kind= 'variable';
-      } else if ('comment' === $type) {
+      } else if ('apidoc' === $type) {
         $this->comment= $value;
+        continue;
+      } else if ('comment' === $type) {
         continue;
       } else {
         throw new Error('Unexpected token '.$value, $this->file, $line);

--- a/src/main/php/lang/ast/Tokens.class.php
+++ b/src/main/php/lang/ast/Tokens.class.php
@@ -103,16 +103,17 @@ class Tokens implements \IteratorAggregate {
         } else if ('/' === $token) {
           $next= $this->tokens->nextToken();
           if ('/' === $next) {
-            $this->tokens->nextToken("\r\n");
+            yield 'comment' => [trim($this->tokens->nextToken("\r\n"), ' '), $line];
             continue;
           } else if ('*' === $next) {
             $comment= '';
             do {
               $t= $this->tokens->nextToken('/');
               $comment.= $t;
-            } while ('*' !== $t[strlen($t)- 1] && $this->tokens->hasMoreTokens());
+            } while ('*' !== $t[strlen($t) - 1] && $this->tokens->hasMoreTokens());
             $comment.= $this->tokens->nextToken('/');
-            yield 'comment' => [trim(preg_replace('/\n\s+\* ?/', "\n", substr($comment, 1, -2))), $line];
+            $kind= '*' === $comment[0] ? 'apidoc' : 'comment';
+            yield $kind => [trim(preg_replace('/\n\s+\* ?/', "\n", substr($comment, 1, -2))), $line];
             $line+= substr_count($comment, "\n");
             continue;
           }
@@ -136,6 +137,8 @@ class Tokens implements \IteratorAggregate {
           } else if ('[' === $comment[0]) {
             $this->tokens->pushBack(substr($comment, 1));
             yield 'operator' => ['#[', $line];
+          } else {
+            yield 'comment' => [trim($comment, ' '), $line];
           }
           continue;
         }

--- a/src/main/php/lang/ast/Tokens.class.php
+++ b/src/main/php/lang/ast/Tokens.class.php
@@ -103,7 +103,7 @@ class Tokens implements \IteratorAggregate {
         } else if ('/' === $token) {
           $next= $this->tokens->nextToken();
           if ('/' === $next) {
-            yield 'comment' => [trim($this->tokens->nextToken("\r\n"), ' '), $line];
+            yield 'comment' => ['//'.$this->tokens->nextToken("\r\n"), $line];
             continue;
           } else if ('*' === $next) {
             $comment= '';
@@ -113,7 +113,7 @@ class Tokens implements \IteratorAggregate {
             } while ('*' !== $t[strlen($t) - 1] && $this->tokens->hasMoreTokens());
             $comment.= $this->tokens->nextToken('/');
             $kind= '*' === $comment[0] ? 'apidoc' : 'comment';
-            yield $kind => [trim(preg_replace('/\n\s+\* ?/', "\n", substr($comment, 1, -2))), $line];
+            yield $kind => ['/*'.$comment, $line];
             $line+= substr_count($comment, "\n");
             continue;
           }
@@ -138,7 +138,7 @@ class Tokens implements \IteratorAggregate {
             $this->tokens->pushBack(substr($comment, 1));
             yield 'operator' => ['#[', $line];
           } else {
-            yield 'comment' => [trim($comment, ' '), $line];
+            yield 'comment' => [$token.$comment, $line];
           }
           continue;
         }

--- a/src/test/php/lang/ast/unittest/LineNumberTest.class.php
+++ b/src/test/php/lang/ast/unittest/LineNumberTest.class.php
@@ -48,7 +48,7 @@ class LineNumberTest {
   #[@test]
   public function after_regular_comment() {
     $this->assertPositions(
-      [['Comment' => 1], ['HERE' => 2]],
+      [['// Comment' => 1], ['HERE' => 2]],
       new Tokens("// Comment\nHERE")
     );
   }
@@ -56,7 +56,7 @@ class LineNumberTest {
   #[@test]
   public function after_apidoc_comment() {
     $this->assertPositions(
-      [['Apidoc' => 1], ['HERE' => 2]],
+      [['/** Apidoc */' => 1], ['HERE' => 2]],
       new Tokens("/** Apidoc */\nHERE")
     );
   }
@@ -64,24 +64,16 @@ class LineNumberTest {
   #[@test]
   public function multi_line_apidoc_comment() {
     $this->assertPositions(
-      [["LINE1\nLINE2" => 1], ['HERE' => 3]],
+      [["/** LINE1\nLINE2 */" => 1], ['HERE' => 3]],
       new Tokens("/** LINE1\nLINE2 */\nHERE")
     );
   }
 
   #[@test]
-  public function multi_line_apidoc_comment_is_trimmed() {
+  public function multi_line_apidoc_comment_is_not_trimmed() {
     $this->assertPositions(
-      [['COMMENT' => 1], ['HERE' => 3]],
-      new Tokens("/** COMMENT\n */\nHERE")
-    );
-  }
-
-  #[@test]
-  public function multi_line_apidoc_comment_leading_stars_removed() {
-    $this->assertPositions(
-      [["LINE1\nLINE2" => 1], ['HERE' => 3]],
-      new Tokens("/** LINE1\n * LINE2 */\nHERE")
+      [["/** Apidoc\n */" => 1], ['HERE' => 3]],
+      new Tokens("/** Apidoc\n */\nHERE")
     );
   }
 

--- a/src/test/php/lang/ast/unittest/LineNumberTest.class.php
+++ b/src/test/php/lang/ast/unittest/LineNumberTest.class.php
@@ -48,16 +48,16 @@ class LineNumberTest {
   #[@test]
   public function after_regular_comment() {
     $this->assertPositions(
-      [['HERE' => 2]],
+      [['Comment' => 1], ['HERE' => 2]],
       new Tokens("// Comment\nHERE")
     );
   }
 
   #[@test]
-  public function apidoc_comment() {
+  public function after_apidoc_comment() {
     $this->assertPositions(
-      [['COMMENT' => 1], ['HERE' => 2]],
-      new Tokens("/** COMMENT */\nHERE")
+      [['Apidoc' => 1], ['HERE' => 2]],
+      new Tokens("/** Apidoc */\nHERE")
     );
   }
 

--- a/src/test/php/lang/ast/unittest/TokensTest.class.php
+++ b/src/test/php/lang/ast/unittest/TokensTest.class.php
@@ -92,21 +92,21 @@ class TokensTest {
 
   #[@test]
   public function regular_comment() {
-    $this->assertTokens([['comment' => 'Comment']], new Tokens('// Comment'));
+    $this->assertTokens([['comment' => '// Comment']], new Tokens('// Comment'));
   }
 
   #[@test]
   public function oneline_comment() {
-    $this->assertTokens([['comment' => 'Comment']], new Tokens('# Comment'));
+    $this->assertTokens([['comment' => '# Comment']], new Tokens('# Comment'));
   }
 
   #[@test]
   public function inline_comment() {
-    $this->assertTokens([['comment' => 'Comment']], new Tokens('/* Comment */'));
+    $this->assertTokens([['comment' => '/* Comment */']], new Tokens('/* Comment */'));
   }
 
   #[@test]
   public function apidoc_comment() {
-    $this->assertTokens([['apidoc' => 'Test']], new Tokens('/** Test */'));
+    $this->assertTokens([['apidoc' => '/** Test */']], new Tokens('/** Test */'));
   }
 }

--- a/src/test/php/lang/ast/unittest/TokensTest.class.php
+++ b/src/test/php/lang/ast/unittest/TokensTest.class.php
@@ -92,11 +92,21 @@ class TokensTest {
 
   #[@test]
   public function regular_comment() {
-    $this->assertTokens([], new Tokens('// Comment'));
+    $this->assertTokens([['comment' => 'Comment']], new Tokens('// Comment'));
+  }
+
+  #[@test]
+  public function oneline_comment() {
+    $this->assertTokens([['comment' => 'Comment']], new Tokens('# Comment'));
+  }
+
+  #[@test]
+  public function inline_comment() {
+    $this->assertTokens([['comment' => 'Comment']], new Tokens('/* Comment */'));
   }
 
   #[@test]
   public function apidoc_comment() {
-    $this->assertTokens([['comment' => 'Test']], new Tokens('/** Test */'));
+    $this->assertTokens([['apidoc' => 'Test']], new Tokens('/** Test */'));
   }
 }

--- a/src/test/php/lang/ast/unittest/parse/CommentTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/CommentTest.class.php
@@ -87,7 +87,7 @@ class CommentTest extends ParseTest {
 
   #[@test]
   public function apidoc_comment_attached_to_next_node() {
-    $this->assertParsed([new ClassDeclaration([], '\\T', null, [], [], [], '@see http://example.org/', 3)], '
+    $this->assertParsed([new ClassDeclaration([], '\\T', null, [], [], [], '/** @see http://example.org/ */', 3)], '
       /** @see http://example.org/ */
       class T { }
     ');

--- a/src/test/php/lang/ast/unittest/parse/CommentTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/CommentTest.class.php
@@ -1,6 +1,6 @@
 <?php namespace lang\ast\unittest\parse;
 
-use lang\ast\nodes\Literal;
+use lang\ast\nodes\{Literal, ClassDeclaration};
 use unittest\Assert;
 
 class CommentTest extends ParseTest {
@@ -82,6 +82,14 @@ class CommentTest extends ParseTest {
        * spanning multiple lines.
        */
       "test";
+    ');
+  }
+
+  #[@test]
+  public function apidoc_comment_attached_to_next_node() {
+    $this->assertParsed([new ClassDeclaration([], '\\T', null, [], [], [], '@see http://example.org/', 3)], '
+      /** @see http://example.org/ */
+      class T { }
     ');
   }
 }


### PR DESCRIPTION
This pull request extends the tokenizer to also yield comments:

* Oneline Bash-style comments: `# ...`
* Oneline C-style comments: `// ...`
* Inline C-style comments, possibly multi-line: `/* ... */`
* Apidoc comments, possibly multi-line: `/** ... */`