### PR TITLE
Improve tokenizer performance by inlining tokenizer code

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,6 @@
   "keywords": ["module", "xp"],
   "require" : {
     "xp-framework/core": "^10.0 | ^9.0 | ^8.0 | ^7.0",
-    "xp-framework/tokenize": "^9.0 | ^8.1",
     "php" : ">=7.0.0"
   },
   "require-dev" : {

--- a/src/main/php/lang/ast/Tokens.class.php
+++ b/src/main/php/lang/ast/Tokens.class.php
@@ -1,160 +1,204 @@
 <?php namespace lang\ast;
 
-use io\streams\InputStream;
+use io\streams\{InputStream, MemoryInputStream};
 use io\{Path, File};
 use lang\FormatException;
-use text\{Tokenizer, StringTokenizer, StreamTokenizer};
 
+/**
+ * Tokenize code.
+ *
+ * @test  xp://lang.ast.unittest.TokensTest
+ */
 class Tokens implements \IteratorAggregate {
-  const DELIMITERS = " |&^?!.:;,@%~=<>(){}[]#+-*/'\$\"\r\n\t";
-
-  private static $operators= [
-    '<' => ['<=', '<<', '<>', '<?', '<=>', '<<='],
-    '>' => ['>=', '>>', '>>='],
-    '=' => ['=>', '==', '==='],
-    '!' => ['!=', '!=='],
+  const DELIMITERS = " \r\n\t'\$\"=,;.:?!(){}[]#+-*/|&^@%~<>";
+  const OPERATORS = [
+    '<' => ['<=>', '<<=', '<=', '<<', '<>', '<?'],
+    '>' => ['>>=', '>=', '>>'],
+    '=' => ['===', '=>', '=='],
+    '!' => ['!==', '!='],
     '&' => ['&&', '&='],
     '|' => ['||', '|='],
     '^' => ['^='],
     '+' => ['+=', '++'],
     '-' => ['-=', '--', '->'],
-    '*' => ['*=', '**', '**='],
+    '*' => ['**=', '*=', '**'],
     '/' => ['/='],
     '~' => ['~='],
     '%' => ['%='],
-    '?' => ['?:', '??', '?->', '??='],
-    '.' => ['.=', '...'],
+    '?' => ['?->', '??=', '?:', '??'],
+    '.' => ['...', '.='],
     ':' => ['::'],
+    '[' => [],
+    ']' => [],
+    '{' => [],
+    '}' => [],
+    '(' => [],
+    ')' => [],
+    ',' => [],
+    ';' => [],
+    '@' => [],
   ]; 
 
-  private $tokens;
+  private $in;
   public $source;
 
   /**
    * Create new iterable tokens from a string or a stream tokenizer
    *
-   * @param  text.Tokenizer|io.streams.InputStream|io.File|io.Path|string $tokens
+   * @param  io.streams.InputStream|io.File|io.Path|string $input
    * @param  ?string $file
    */
   public function __construct($input, $file= null) {
-    if ($input instanceof Tokenizer) {
-      $this->tokens= $input;
-      $this->tokens->delimiters= self::DELIMITERS;
-      $this->tokens->returnDelims= true;
-      $this->source= $file ?? '(tokens)';
-    } else if ($input instanceof InputStream) {
-      $this->tokens= new StreamTokenizer($input, self::DELIMITERS, true);
+    if ($input instanceof InputStream) {
+      $this->in= $input;
       $this->source= $file ?? '(stream)';
     } else if ($input instanceof Path) {
-      $this->tokens= new StreamTokenizer($input->asFile()->in(), self::DELIMITERS, true);
-      $this->source= $file ?? $path->toString();
+      $this->in= $input->asFile()->in();
+      $this->source= $file ?? $input->toString();
     } else if ($input instanceof File) {
-      $this->tokens= new StreamTokenizer($input->in(), self::DELIMITERS, true);
+      $this->in= $input->in();
       $this->source= $file ?? $input->getURI();
     } else {
-      $this->tokens= new StringTokenizer($input, self::DELIMITERS, true);
+      $this->in= new MemoryInputStream($input);
       $this->source= $file ?? '(string)';
     }
   }
 
   /** @return php.Iterator */
   public function getIterator() {
+    $buffer= '';
+    $length= $offset= 0;
+
+    // Read until either delimiters are encountered or EOF
+    $next= function($delimiters) use(&$buffer, &$length, &$offset) {
+      do {
+        $span= strcspn($buffer, $delimiters, $offset);
+        if ($offset + $span + 1 < $length || 0 === $this->in->available()) {
+          if (0 === $span) {
+            return $buffer[$offset++] ?? null;
+          } else {
+            $token= substr($buffer, $offset, $span);
+            $offset+= $span;
+            return $token;
+          }
+        }
+        $buffer.= $this->in->read(8192);
+        $length= strlen($buffer);
+      } while (true);
+    };
+
+    // Parse into tokens
     $line= 1;
-    while (null !== ($token= $this->tokens->nextToken())) {
-      if ('$' === $token) {
-        yield 'variable' => [$this->tokens->nextToken(), $line];
-      } else if ('"' === $token || "'" === $token) {
+    do {
+      $token= $next(self::DELIMITERS);
+
+      if ("\n" === $token) {
+        $line++;
+      } else if ("\r" === $token || "\t" === $token || ' ' === $token) {
+        // Skip over whitespace
+      } else if ("'" === $token || '"' === $token) {
         $string= $token;
         $end= '\\'.$token;
         do {
-          $t= $this->tokens->nextToken($end);
-          if (null === $t) {
+          $chunk= $next($end);
+          if (null === $chunk) {
             throw new FormatException('Unclosed string literal starting at line '.$line);
-          } else if ('\\' === $t) {
-            $string.= $t.$this->tokens->nextToken($end);
+          } else if ('\\' === $chunk) {
+            $string.= $chunk.$next($end);
           } else {
-            $string.= $t;
+            $string.= $chunk;
           }
-        } while ($token !== $t);
+        } while ($token !== $chunk);
 
         yield 'string' => [$string, $line];
         $line+= substr_count($string, "\n");
-      } else if ("\n" === $token) {
-        $line++;
-      } else if ("\r" === $token || "\t" === $token || ' ' === $token) {
-        // Skip
-      } else if (0 === strcspn($token, '0123456789')) {
-        if ('.' === ($next= $this->tokens->nextToken())) {
-          yield 'decimal' => [str_replace('_', '', $token.$next.$this->tokens->nextToken()), $line];
+      } else if ('$' === $token) {
+        yield 'variable' => [$next(self::DELIMITERS), $line];
+      } else if ('#' === $token) {
+        $t= $next(self::DELIMITERS);
+        if ('[' === $t) {
+          $t= $next(self::DELIMITERS);
+          if ('@' === $t) {
+            yield 'operator' => ['#[@', $line];
+
+            // Uncomment all following lines by replacing "#" with spaces
+            $start= $offset - 1;
+            $next("\r\n");
+            do {
+              $chunk= $next("\r\n");
+              if ("\n" === $chunk || "\r" === $chunk) continue;
+              $s= strspn($chunk, ' ');
+              if ('#' !== $chunk[$s]) break;
+
+              $buffer[$offset - strlen($chunk) + $s]= ' ';
+            } while (true);
+            $offset= $start;
+          } else {
+            $offset-= strlen($t);
+            yield 'operator' => ['#[', $line];
+          }
         } else {
-          $this->tokens->pushBack($next);
+          yield 'comment' => ['#'.$t.$next("\r\n"), $line];
+        }
+      } else if (0 === strcspn($token, '0123456789')) {
+        if ('.' === ($t= $next(self::DELIMITERS))) {
+          yield 'decimal' => [str_replace('_', '', $token.$t.$next(self::DELIMITERS)), $line];
+        } else {
+          $offset-= strlen($t);
           yield 'integer' => [str_replace('_', '', $token), $line];
         }
-      } else if (0 === strcspn($token, self::DELIMITERS)) {
+      } else if (isset(self::OPERATORS[$token])) {
+
+        // Resolve .5 (a floating point number) vs `.`, the concatenation operator
+        // and C-style comments vs. `/` and `/=` division operators by looking ahead
         if ('.' === $token) {
-          $next= $this->tokens->nextToken();
-          if (0 === strcspn($next, '0123456789')) {
-            yield 'decimal' => [".$next", $line];
+          $t= $next(self::DELIMITERS);
+          if (0 === strcspn($t, '0123456789')) {
+            yield 'decimal' => [".$t", $line];
             continue;
           }
-          $this->tokens->pushBack($next);
+          $offset-= strlen($t);
         } else if ('/' === $token) {
-          $next= $this->tokens->nextToken();
-          if ('/' === $next) {
-            yield 'comment' => ['//'.$this->tokens->nextToken("\r\n"), $line];
+          $t= $next(self::DELIMITERS);
+          if ('/' === $t) {
+            yield 'comment' => ['//'.$next("\r\n"), $line];
             continue;
-          } else if ('*' === $next) {
+          } else if ('*' === $t) {
             $comment= '';
             do {
-              $t= $this->tokens->nextToken('/');
-              $comment.= $t;
-            } while ('*' !== $t[strlen($t) - 1] && $this->tokens->hasMoreTokens());
-            $comment.= $this->tokens->nextToken('/');
+              $chunk= $next('/');
+              $comment.= $chunk;
+            } while (null !== $chunk && '*' !== $chunk[strlen($chunk) - 1]);
+            $comment.= $next('/');
             yield 'comment' => ['/*'.$comment, $line];
             $line+= substr_count($comment, "\n");
             continue;
           }
-          $this->tokens->pushBack($next);
-        } else if ('#' === $token) {
-          $comment= $this->tokens->nextToken("\r\n");
-
-          // XP Annotations: Consume all consecutive lines, uncommenting them
-          if (0 === strncmp($comment, '[@', 2)) {
-            $comment.= $this->tokens->nextToken("\r\n");
-            $next= '#';
-            do {
-              $s= strspn($next, ' ');
-              if ('#' !== $next[$s]) break;
-              $comment.= substr($next, $s + 1);
-              $next= $this->tokens->nextToken("\r\n").$this->tokens->nextToken("\r\n");
-            } while ($this->tokens->hasMoreTokens());
-
-            $this->tokens->pushBack(substr($comment, 1).$next);
-            yield 'operator' => ['#[@', $line];
-          } else if ('[' === $comment[0]) {
-            $this->tokens->pushBack(substr($comment, 1));
-            yield 'operator' => ['#[', $line];
-          } else {
-            yield 'comment' => [$token.$comment, $line];
-          }
-          continue;
+          $offset-= strlen($t);
         }
 
-        if (isset(self::$operators[$token])) {
-          $combined= $token;
-          foreach (self::$operators[$token] as $operator) {
-            while (strlen($combined) < strlen($operator) && $this->tokens->hasMoreTokens()) {
-              $combined.= $this->tokens->nextToken();
+        // Handle combined operators. First, ensure we have enough bytes in our buffer
+        // Our longest operator is 3 characters, hardcode this here.
+        if (self::OPERATORS[$token]) {
+          $offset--;
+          while ($offset + 3 > $length && $this->in->available()) {
+            $buffer.= $this->in->read(8192);
+            $length= strlen($buffer);
+          }
+          foreach (self::OPERATORS[$token] as $operator) {
+            if ($offset + strlen($operator) > $length) continue;
+            if (0 === substr_compare($buffer, $operator, $offset, strlen($operator))) {
+              $token= $operator;
+              break;
             }
-            $combined === $operator && $token= $combined;
           }
-
-          $this->tokens->pushBack(substr($combined, strlen($token)));
+          $offset+= strlen($token);
         }
+
         yield 'operator' => [$token, $line];
       } else {
         yield 'name' => [$token, $line];
       }
-    }
+    } while ($offset < $length);
   }
 }


### PR DESCRIPTION
## Measures taken
The following code changes were made:

* Inline tokenizer code from tokenizer library
* Change all string operations to use offsets instead of creating various new strings via `substr()`
* Use same offset for pushback operations instead of actually pushing back strings
* Reorder code to handle most common tokens first

*We can also drop `xp-framework/tokenize` from dependencies this way.*

## Performance

To measure performance, a script was written to tokenize all classes inside `xp-framework/core`.

**Before:**
```bash
$ xp tokenize.script.php ../core/src/
# ...
409 files with 210854 tokens
0.478 seconds taken, 1645.37 kB used
```

**After:**
```bash
$ xp tokenize.script.php ../core/src/
# ...
409 files with 210854 tokens
0.342 seconds taken, 1643.38 kB used
```

*While the memory usage has not changed, the script now tokenizes the code base ~150 milliseconds faster* 