### PR TITLE
Add syntactic support for named arguments

### DIFF
--- a/src/test/php/lang/ast/unittest/parse/InvokeTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/InvokeTest.class.php
@@ -53,4 +53,13 @@ class InvokeTest extends ParseTest {
       'test(1, 2, );'
     );
   }
+
+  #[@test]
+  public function invoke_function_with_positional_and_named_arguments() {
+    $arguments= [0 => new Literal('1', self::LINE), 'named' => new Literal('2', self::LINE)];
+    $this->assertParsed(
+      [new InvokeExpression(new Literal('test', self::LINE), $arguments, self::LINE)],
+      'test(1, named: 2);'
+    );
+  }
 }

--- a/src/test/php/lang/ast/unittest/parse/NamedArgumentsTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/NamedArgumentsTest.class.php
@@ -1,0 +1,65 @@
+<?php namespace lang\ast\unittest\parse;
+
+use lang\ast\nodes\{InstanceExpression, InvokeExpression, Literal, Variable};
+use unittest\Assert;
+
+/**
+ * Named argumwents
+ *
+ * @see  https://wiki.php.net/rfc/named_params
+ */
+class NamedArgumentsTest extends ParseTest {
+
+  /**
+   * Assertion helper
+   * 
+   * @param  string[] $names
+   * @param  array $arguments
+   * @throws unittest.AssertionFailedError
+   */
+  private function assertNamed($names, $arguments) {
+    Assert::equals($names, array_keys($arguments));
+  }
+
+  #[@test]
+  public function one_named() {
+    $node= $this->parse('func(named: 1);')->tree()->children()[0];
+    $this->assertNamed(['named'], $node->arguments);
+  }
+
+  #[@test]
+  public function named_and_positional() {
+    $node= $this->parse('func(1, 2, a: 3, b: 4);')->tree()->children()[0];
+    $this->assertNamed([0, 1, 'a', 'b'], $node->arguments);
+  }
+
+  #[@test]
+  public function function_call() {
+    $node= $this->parse('func(1, named: 2);')->tree()->children()[0];
+    $this->assertNamed([0, 'named'], $node->arguments);
+  }
+
+  #[@test]
+  public function instance_method_call() {
+    $node= $this->parse('$this->func(1, named: 2);')->tree()->children()[0];
+    $this->assertNamed([0, 'named'], $node->arguments);
+  }
+
+  #[@test]
+  public function class_method_call() {
+    $node= $this->parse('self::func(1, named: 2);')->tree()->children()[0];
+    $this->assertNamed([0, 'named'], $node->member->arguments);
+  }
+
+  #[@test]
+  public function new_operator() {
+    $node= $this->parse('new T(1, named: 2);')->tree()->children()[0];
+    $this->assertNamed([0, 'named'], $node->arguments);
+  }
+
+  #[@test]
+  public function attributes() {
+    $node= $this->parse('#[Values(using: "$values")] class T { }')->tree()->children()[0];
+    $this->assertNamed(['using'], $node->annotations['Values']);
+  }
+}


### PR DESCRIPTION
See https://wiki.php.net/rfc/named_params and xp-framework/compiler#13. 

**Note:** This only adds *syntactic* support, the compiler needs to be changed to support native PHP 8 syntax for this:

```bash
$ echo "<?php invoke(1, named: 2)" | xp compile -t PHP8.0 - 2>/dev/null
<?php ;invoke(1, 2, );
```

*As you can see, the argument name is simply swallowed at the moment*