### PR TITLE
Implement values as complement to annotations

### DIFF
--- a/src/main/php/lang/ast/Tokens.class.php
+++ b/src/main/php/lang/ast/Tokens.class.php
@@ -137,6 +137,8 @@ class Tokens implements \IteratorAggregate {
             $offset-= strlen($t);
             yield 'operator' => ['#[', $line];
           }
+        } else if ('$' === $t) {
+          yield 'operator' => ['#$', $line];
         } else {
           yield 'comment' => ['#'.$t.$next("\r\n"), $line];
         }

--- a/src/main/php/lang/ast/nodes/Annotated.class.php
+++ b/src/main/php/lang/ast/nodes/Annotated.class.php
@@ -3,7 +3,7 @@
 use lang\ast\Node;
 
 abstract class Annotated extends Node {
-  public $annotations;
+  public $annotations, $values;
 
   /**
    * Returns an annotation for a given name, or NULL if no annotation

--- a/src/test/php/lang/ast/unittest/parse/ValuesTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/ValuesTest.class.php
@@ -1,0 +1,83 @@
+<?php namespace lang\ast\unittest\parse;
+
+use lang\ast\nodes\{Annotated, Literal, LambdaExpression};
+use unittest\Assert;
+
+/** @see https://github.com/xp-framework/rfc/issues/336 */
+class ValuesTest extends ParseTest {
+
+  /**
+   * Parses source into type
+   *
+   * @param  string $source
+   * @return lang.ast.TypeDeclaration
+   */
+  private function type($source) {
+    return $this->parse($source)->tree()->type('T');
+  }
+
+  /**
+   * Assertion helper
+   *
+   * @param  var $expected
+   * @param  lang.ast.Node $node
+   * @throws unittest.AssertionFailedError
+   * @return void
+   */
+  private function assertValues($expected, $node) {
+    Assert::equals($expected, cast($node, Annotated::class)->values);
+  }
+
+  #[@test]
+  public function on_class() {
+    $this->assertValues(
+      ['using' => new Literal('"value"', self::LINE)],
+      $this->type('#$using: "value" class T { }')
+    );
+  }
+
+  #[@test]
+  public function on_constant() {
+    $this->assertValues(
+      ['using' => new Literal('"value"', self::LINE)],
+      $this->type('class T { #$using: "value" const FIXTURE = "test"; }')->constant('FIXTURE')
+    );
+  }
+
+  #[@test]
+  public function on_property() {
+    $this->assertValues(
+      ['using' => new Literal('"value"', self::LINE)],
+      $this->type('class T { #$using: "value" public $fixture; }')->property('fixture')
+    );
+  }
+
+  #[@test]
+  public function on_method() {
+    $this->assertValues(
+      ['using' => new Literal('"value"', self::LINE)],
+      $this->type('class T { #$using: "value" public function fixture() { } }')->method('fixture')
+    );
+  }
+
+  #[@test]
+  public function values_on_multiple_lines() {
+    $this->assertValues(
+      ['author' => new Literal('"test"', self::LINE + 1), 'version'  => new Literal('1', self::LINE + 2)],
+      $this->type('
+        #$author: "test"
+        #$version: 1
+        class T { }
+      ')
+    );
+  }
+
+  #[@test]
+  public function with_function() {
+    $type= $this->type('
+      #$using: fn() => version_compare(PHP_VERSION, "7.0.0", ">=")
+      class T { }
+    ');
+    Assert::instance(LambdaExpression::class, cast($type, Annotated::class)->values['using']);
+  }
+}


### PR DESCRIPTION
See xp-framework/rfc#336, values are key/value pairs that can be attached to types and type members. They serve as a complement to PHP 8 attributes which do not support arbitrary expressions in their argument lists.

## Example

```php
use unittest\{Assert, Test, Values};

class ListOfTest {

  #$values: [[new ListOf()], [ListOf::$EMPTY]]
  #[Test, Values(using: '$values')]
  public function size_of_empty($list) {
    Assert::equals(0, $list->size());
  }
}
```

*Note: Accessing values needs to be implemented by libraries, no automatic coupling of the `Values` attributes and the `$values` value is done!*