### PR TITLE
Convert test suite to baseless

### DIFF
--- a/src/test/php/lang/ast/unittest/TokensTest.class.php
+++ b/src/test/php/lang/ast/unittest/TokensTest.class.php
@@ -32,7 +32,7 @@ class TokensTest {
     $this->assertTokens([['string' => $input]], new Tokens($input));
   }
 
-  #[Test, Expect(['class' => FormatException::class, 'withMessage' => '/Unclosed string literal/']), Values(['"', "'", '"Test', "'Test"])]
+  #[Test, Expect(class: FormatException::class, withMessage: '/Unclosed string literal/'), Values(['"', "'", '"Test', "'Test"])]
   public function unclosed_string_literals($input) {
     $t= (new Tokens($input))->getIterator(); 
     $t->current();
@@ -61,8 +61,8 @@ class TokensTest {
   #[Test]
   public function annotation() {
     $this->assertTokens(
-      [['operator' => '<<'], ['name' => 'test'], ['operator' => '>>']],
-      new Tokens('<<test>>')
+      [['operator' => '#['], ['name' => 'Test'], ['operator' => ']']],
+      new Tokens('#[Test]')
     );
   }
 

--- a/src/test/php/lang/ast/unittest/TypeTest.class.php
+++ b/src/test/php/lang/ast/unittest/TypeTest.class.php
@@ -22,7 +22,7 @@ class TypeTest {
     ;
   }
 
-  #[Test, Values(['string', 'int', 'bool', 'mixed', 'float', 'array', 'object', 'resource', 'iterable', 'callable', 'double',])]
+  #[Test, Values(['string', 'int', 'bool', 'mixed', 'float', 'array', 'object', 'resource', 'iterable', 'callable', 'double'])]
   public function literals($t) {
     Assert::equals(new IsLiteral($t), $this->parse($t));
   }

--- a/src/test/php/lang/ast/unittest/nodes/ArrayLiteralTest.class.php
+++ b/src/test/php/lang/ast/unittest/nodes/ArrayLiteralTest.class.php
@@ -1,7 +1,7 @@
 <?php namespace lang\ast\unittest\nodes;
 
 use lang\ast\nodes\{ArrayLiteral, Literal};
-use unittest\Test;
+use unittest\{Assert, Test};
 
 class ArrayLiteralTest extends NodeTest {
 
@@ -12,30 +12,30 @@ class ArrayLiteralTest extends NodeTest {
 
   #[Test]
   public function empty_values() {
-    $this->assertEquals([], (new ArrayLiteral([]))->values);
+    Assert::equals([], (new ArrayLiteral([]))->values);
   }
 
   #[Test]
   public function array_values() {
     $values= [[null, new Literal(1)]];
-    $this->assertEquals($values, (new ArrayLiteral($values))->values);
+    Assert::equals($values, (new ArrayLiteral($values))->values);
   }
 
   #[Test]
   public function map_values() {
     $values= [[new Literal('"one"'), new Literal(1)]];
-    $this->assertEquals($values, (new ArrayLiteral($values))->values);
+    Assert::equals($values, (new ArrayLiteral($values))->values);
   }
 
   #[Test]
   public function array_children() {
     $values= [[null, new Literal(1)]];
-    $this->assertEquals([new Literal(1)], $this->childrenOf(new ArrayLiteral($values)));
+    Assert::equals([new Literal(1)], $this->childrenOf(new ArrayLiteral($values)));
   }
 
   #[Test]
   public function map_children() {
     $values= [[new Literal('"one"'), new Literal(1)]];
-    $this->assertEquals([new Literal('"one"'), new Literal(1)], $this->childrenOf(new ArrayLiteral($values)));
+    Assert::equals([new Literal('"one"'), new Literal(1)], $this->childrenOf(new ArrayLiteral($values)));
   }
 }

--- a/src/test/php/lang/ast/unittest/nodes/CaseLabelTest.class.php
+++ b/src/test/php/lang/ast/unittest/nodes/CaseLabelTest.class.php
@@ -1,13 +1,13 @@
 <?php namespace lang\ast\unittest\nodes;
 
 use lang\ast\nodes\{CaseLabel, Literal};
-use unittest\Test;
+use unittest\{Assert, Before, Test};
 
 class CaseLabelTest extends NodeTest {
   private $expression;
 
-  /** @return void */
-  public function setUp() {
+  #[Before]
+  public function newExpression() {
     $this->expression= new Literal(0);
   }
 
@@ -18,18 +18,18 @@ class CaseLabelTest extends NodeTest {
 
   #[Test]
   public function normal_label_has_expression() {
-    $this->assertEquals($this->expression, (new CaseLabel($this->expression, []))->expression);
+    Assert::equals($this->expression, (new CaseLabel($this->expression, []))->expression);
   }
 
   #[Test]
   public function default_has_no_expression() {
-    $this->assertNull((new CaseLabel(null, []))->expression);
+    Assert::null((new CaseLabel(null, []))->expression);
   }
 
   #[Test]
   public function normal_label_children() {
     $body= [$this->returns('"no"')];
-    $this->assertEquals(
+    Assert::equals(
       array_merge([$this->expression], $body),
       $this->childrenOf(new CaseLabel($this->expression, $body))
     );
@@ -38,7 +38,7 @@ class CaseLabelTest extends NodeTest {
   #[Test]
   public function default_children() {
     $body= [$this->returns('"no"')];
-    $this->assertEquals(
+    Assert::equals(
       $body,
       $this->childrenOf(new CaseLabel(null, $body))
     );

--- a/src/test/php/lang/ast/unittest/nodes/CatchStatementTest.class.php
+++ b/src/test/php/lang/ast/unittest/nodes/CatchStatementTest.class.php
@@ -2,13 +2,13 @@
 
 use lang\IllegalArgumentException;
 use lang\ast\nodes\{CatchStatement, Variable};
-use unittest\Test;
+use unittest\{Assert, Before, Test};
 
 class CatchStatementTest extends NodeTest {
   private $types;
 
-  /** @return void */
-  public function setUp() {
+  #[Before]
+  public function newTypes() {
     $this->types= [IllegalArgumentException::class];
   }
 
@@ -19,23 +19,23 @@ class CatchStatementTest extends NodeTest {
 
   #[Test]
   public function types() {
-    $this->assertEquals($this->types, (new CatchStatement($this->types, 'e', []))->types);
+    Assert::equals($this->types, (new CatchStatement($this->types, 'e', []))->types);
   }
 
   #[Test]
   public function body() {
     $body= [$this->returns('true')];
-    $this->assertEquals($body, (new CatchStatement($this->types, 'e', $body))->body);
+    Assert::equals($body, (new CatchStatement($this->types, 'e', $body))->body);
   }
 
   #[Test]
   public function variable() {
-    $this->assertEquals('e', (new CatchStatement($this->types, 'e', []))->variable);
+    Assert::equals('e', (new CatchStatement($this->types, 'e', []))->variable);
   }
 
   #[Test]
   public function children() {
     $block= [$this->returns('true')];
-    $this->assertEquals($block, $this->childrenOf(new CatchStatement($this->types, 'e', $block)));
+    Assert::equals($block, $this->childrenOf(new CatchStatement($this->types, 'e', $block)));
   }
 }

--- a/src/test/php/lang/ast/unittest/nodes/IfStatementTest.class.php
+++ b/src/test/php/lang/ast/unittest/nodes/IfStatementTest.class.php
@@ -1,13 +1,13 @@
 <?php namespace lang\ast\unittest\nodes;
 
 use lang\ast\nodes\{IfStatement, Variable};
-use unittest\Test;
+use unittest\{Assert, Before, Test};
 
 class IfStatementTest extends NodeTest {
   private $condition;
 
-  /** @return void */
-  public function setUp() {
+  #[Before]
+  public function condition() {
     $this->condition= new Variable('condition');
   }
 
@@ -18,19 +18,19 @@ class IfStatementTest extends NodeTest {
 
   #[Test]
   public function expression() {
-    $this->assertEquals($this->condition, (new IfStatement($this->condition, [], null))->expression);
+    Assert::equals($this->condition, (new IfStatement($this->condition, [], null))->expression);
   }
 
   #[Test]
   public function body() {
     $body= [$this->returns('true')];
-    $this->assertEquals($body, (new IfStatement($this->condition, $body, null))->body);
+    Assert::equals($body, (new IfStatement($this->condition, $body, null))->body);
   }
 
   #[Test]
   public function otherwise() {
     $otherwise= [$this->returns('true')];
-    $this->assertEquals($otherwise, (new IfStatement($this->condition, [], $otherwise))->otherwise);
+    Assert::equals($otherwise, (new IfStatement($this->condition, [], $otherwise))->otherwise);
   }
 
   #[Test]
@@ -38,7 +38,7 @@ class IfStatementTest extends NodeTest {
     $body= [$this->returns('true')];
     $otherwise= [$this->returns('false')];
 
-    $this->assertEquals(
+    Assert::equals(
       array_merge([$this->condition], $body, $otherwise),
       $this->childrenOf(new IfStatement($this->condition, $body, $otherwise))
     );

--- a/src/test/php/lang/ast/unittest/nodes/LiteralTest.class.php
+++ b/src/test/php/lang/ast/unittest/nodes/LiteralTest.class.php
@@ -1,7 +1,7 @@
 <?php namespace lang\ast\unittest\nodes;
 
 use lang\ast\nodes\Literal;
-use unittest\Test;
+use unittest\{Assert, Test};
 
 class LiteralTest extends NodeTest {
 
@@ -12,6 +12,6 @@ class LiteralTest extends NodeTest {
 
   #[Test]
   public function expression() {
-    $this->assertEquals('true', (new Literal('true'))->expression);
+    Assert::equals('true', (new Literal('true'))->expression);
   }
 }

--- a/src/test/php/lang/ast/unittest/nodes/NodeTest.class.php
+++ b/src/test/php/lang/ast/unittest/nodes/NodeTest.class.php
@@ -1,9 +1,8 @@
 <?php namespace lang\ast\unittest\nodes;
 
 use lang\ast\nodes\{Literal, ReturnStatement};
-use unittest\TestCase;
 
-abstract class NodeTest extends TestCase {
+abstract class NodeTest {
 
   protected function childrenOf($node) {
     $result= [];

--- a/src/test/php/lang/ast/unittest/nodes/ReturnStatementTest.class.php
+++ b/src/test/php/lang/ast/unittest/nodes/ReturnStatementTest.class.php
@@ -1,29 +1,29 @@
 <?php namespace lang\ast\unittest\nodes;
 
 use lang\ast\nodes\{Literal, ReturnStatement};
-use unittest\Test;
+use unittest\{Assert, Test};
 
 class ReturnStatementTest extends NodeTest {
 
   #[Test]
   public function return_without_expression() {
-    $this->assertNull((new ReturnStatement())->expression);
+    Assert::null((new ReturnStatement())->expression);
   }
 
   #[Test]
   public function return_with_expression() {
     $expr= new Literal(1);
-    $this->assertEquals($expr, (new ReturnStatement($expr))->expression);
+    Assert::equals($expr, (new ReturnStatement($expr))->expression);
   }
 
   #[Test]
   public function children_without_expression() {
-    $this->assertEquals([], (new ReturnStatement())->children());
+    Assert::equals([], (new ReturnStatement())->children());
   }
 
   #[Test]
   public function children_with_expression() {
     $expr= new Literal(1);
-    $this->assertEquals([$expr], (new ReturnStatement($expr))->children());
+    Assert::equals([$expr], (new ReturnStatement($expr))->children());
   }
 }

--- a/src/test/php/lang/ast/unittest/nodes/SwitchStatementTest.class.php
+++ b/src/test/php/lang/ast/unittest/nodes/SwitchStatementTest.class.php
@@ -1,12 +1,13 @@
 <?php namespace lang\ast\unittest\nodes;
 
 use lang\ast\nodes\{CaseLabel, Literal, SwitchStatement, Variable};
-use unittest\Test;
+use unittest\{Assert, Test};
 
 class SwitchStatementTest extends NodeTest {
   private $expression;
 
   /** @return void */
+  #[Before]
   public function setUp() {
     $this->expression= new Variable('expression');
   }
@@ -18,12 +19,12 @@ class SwitchStatementTest extends NodeTest {
 
   #[Test]
   public function expression() {
-    $this->assertEquals($this->expression, (new SwitchStatement($this->expression, []))->expression);
+    Assert::equals($this->expression, (new SwitchStatement($this->expression, []))->expression);
   }
 
   #[Test]
   public function empty_cases() {
-    $this->assertEquals([], (new SwitchStatement($this->expression, []))->cases);
+    Assert::equals([], (new SwitchStatement($this->expression, []))->cases);
   }
 
   #[Test]
@@ -33,7 +34,7 @@ class SwitchStatementTest extends NodeTest {
       new CaseLabel(new Literal(1), [$this->returns('"one"')]),
       new CaseLabel(null, [$this->returns('"more"')])
     ];
-    $this->assertEquals($cases, (new SwitchStatement($this->expression, $cases))->cases);
+    Assert::equals($cases, (new SwitchStatement($this->expression, $cases))->cases);
   }
 
   #[Test]
@@ -43,7 +44,7 @@ class SwitchStatementTest extends NodeTest {
       new CaseLabel(new Literal(1), [$this->returns('"one"')]),
       new CaseLabel(null, [$this->returns('"more"')])
     ];
-    $this->assertEquals(
+    Assert::equals(
       array_merge([$this->expression], $cases),
       $this->childrenOf(new SwitchStatement($this->expression, $cases))
     );

--- a/src/test/php/lang/ast/unittest/parse/ClosuresTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/ClosuresTest.class.php
@@ -7,9 +7,8 @@ use unittest\{Assert, Before, Test};
 class ClosuresTest extends ParseTest {
   private $returns;
 
-  /** @return void */
   #[Before]
-  public function setUp() {
+  public function returns() {
     $this->returns= new ReturnStatement(
       new BinaryExpression(
         new Variable('a', self::LINE),

--- a/src/test/php/lang/ast/unittest/parse/ConditionalTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/ConditionalTest.class.php
@@ -6,9 +6,8 @@ use unittest\{Assert, Before, Test};
 class ConditionalTest extends ParseTest {
   private $blocks;
 
-  /** @return void */
   #[Before]
-  public function setUp() {
+  public function blocks() {
     $this->blocks= [
       1 => [new InvokeExpression(new Literal('action1', self::LINE), [], self::LINE)],
       2 => [new InvokeExpression(new Literal('action2', self::LINE), [], self::LINE)]

--- a/src/test/php/lang/ast/unittest/parse/LambdasTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/LambdasTest.class.php
@@ -6,9 +6,8 @@ use unittest\{Assert, Before, Test};
 class LambdasTest extends ParseTest {
   private $expression;
 
-  /** @return void */
   #[Before]
-  public function setUp() {
+  public function expression() {
     $this->expression= new BinaryExpression(new Variable('a', self::LINE), '+', new Literal('1', self::LINE), self::LINE);
   }
 

--- a/src/test/php/lang/ast/unittest/parse/LoopsTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/LoopsTest.class.php
@@ -6,9 +6,8 @@ use unittest\{Assert, Before, Test};
 class LoopsTest extends ParseTest {
   private $loop;
 
-  /** @return void */
   #[Before]
-  public function setUp() {
+  public function expression() {
     $this->loop= new InvokeExpression(new Literal('loop', self::LINE), [], self::LINE);
   }
 


### PR DESCRIPTION
Uses new `Assert` DSL instead of extending `unittest.TestCase`.