### PR TITLE
Refactor parsing to allow blocks anywhere an expression is allowed

### DIFF
--- a/src/main/php/lang/ast/syntax/PHP.class.php
+++ b/src/main/php/lang/ast/syntax/PHP.class.php
@@ -279,6 +279,12 @@ class PHP extends Language {
       }
     });
 
+    $this->prefix('{', 0, function($parse, $token) {
+      $statements= $this->statements($parse);
+      $parse->expecting('}', 'block');
+      return new Block($statements, $token->line);
+    });
+
     $this->prefix('[', 0, function($parse, $token) {
       $values= [];
       while (']' !== $parse->token->value) {
@@ -369,15 +375,7 @@ class PHP extends Language {
       $signature= $this->signature($parse);
       $parse->expecting('=>', 'fn');
 
-      if ('{' === $parse->token->value) {
-        $parse->expecting('{', 'fn');
-        $statements= $this->statements($parse);
-        $parse->expecting('}', 'fn');
-      } else {
-        $statements= $this->expression($parse, 0);
-      }
-
-      return new LambdaExpression($signature, $statements, $token->line);
+      return new LambdaExpression($signature, $this->expression($parse, 0), $token->line);
     });
 
     $this->prefix('function', 0, function($parse, $token) {
@@ -1398,7 +1396,7 @@ class PHP extends Language {
     return new Signature($parameters, $return);
   }
 
-   public function block($parse) {
+  public function block($parse) {
     if ('{'  === $parse->token->value) {
       $parse->forward();
       $block= $this->statements($parse);

--- a/src/test/php/lang/ast/unittest/parse/LambdasTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/LambdasTest.class.php
@@ -1,6 +1,6 @@
 <?php namespace lang\ast\unittest\parse;
 
-use lang\ast\nodes\{BinaryExpression, InvokeExpression, LambdaExpression, Literal, Parameter, ReturnStatement, Signature, Variable};
+use lang\ast\nodes\{BinaryExpression, InvokeExpression, LambdaExpression, Literal, Parameter, ReturnStatement, Signature, Variable, Block};
 use unittest\{Assert, Before, Test};
 
 class LambdasTest extends ParseTest {
@@ -17,7 +17,6 @@ class LambdasTest extends ParseTest {
       [new LambdaExpression(new Signature([new Parameter('a', null)], null), $this->expression, self::LINE)],
       'fn($a) => $a + 1;'
     );
-    \xp::gc();
   }
 
   #[Test]
@@ -30,15 +29,17 @@ class LambdasTest extends ParseTest {
       )],
       'execute(fn($a) => $a + 1);'
     );
-    \xp::gc();
   }
 
   #[Test]
-  public function short_closure_with_braces() {
+  public function short_closure_with_block() {
     $this->assertParsed(
-      [new LambdaExpression(new Signature([new Parameter('a', null)], null), [new ReturnStatement($this->expression, self::LINE)], self::LINE)],
+      [new LambdaExpression(
+        new Signature([new Parameter('a', null)], null),
+        new Block([new ReturnStatement($this->expression, self::LINE)], self::LINE),
+        self::LINE
+      )],
       'fn($a) => { return $a + 1; };'
     );
-    \xp::gc();
   }
 }


### PR DESCRIPTION
This not only allows `fn() => { ... }` but also `match ($arg) { 200 => { ... }}`. Changes lambda expressions to contain a `lang.ast.nodes.Block` instead of an array, requiring downstream changes to be made.