### PR TITLE
Stream tokens directly instead of using if/else cascade

### DIFF
--- a/src/main/php/lang/ast/Token.class.php
+++ b/src/main/php/lang/ast/Token.class.php
@@ -4,9 +4,8 @@ use lang\Value;
 use util\Objects;
 
 class Token implements Value {
-  public $symbol, $value, $kind;
+  public $symbol, $value, $kind, $line;
   public $comment= null;
-  public $line= -1;
 
   /**
    * Creates a new node
@@ -14,11 +13,13 @@ class Token implements Value {
    * @param lang.ast.Symbol $symbol
    * @param string $kind
    * @param var $value
+   * @param int $line
    */
-  public function __construct(Symbol $symbol= null, $kind= null, $value= null) {
+  public function __construct(Symbol $symbol= null, $kind= null, $value= null, $line= -1) {
     $this->symbol= $symbol;
     $this->kind= $kind;
     $this->value= $value;
+    $this->line= $line;
   }
 
   /** @return string */

--- a/src/test/php/lang/ast/unittest/LineNumberTest.class.php
+++ b/src/test/php/lang/ast/unittest/LineNumberTest.class.php
@@ -1,9 +1,10 @@
 <?php namespace lang\ast\unittest;
 
-use lang\ast\Tokens;
+use lang\ast\{Tokens, Language};
 use unittest\{Assert, Test};
 
 class LineNumberTest {
+  private $language;
 
   /**
    * Assertion helper
@@ -15,10 +16,15 @@ class LineNumberTest {
    */
   private function assertPositions($expected, $tokens) {
     $actual= [];
-    foreach ($tokens as $type => $value) {
-      $actual[]= [$value[0] => $value[1]];
+    foreach ($tokens->iterator($this->language) as $token) {
+      $actual[]= [$token->value => $token->line];
     }
     Assert::equals($expected, $actual);
+  }
+
+  #[Before]
+  public function language() {
+    $this->language= Language::named('PHP');
   }
 
   #[Test]

--- a/src/test/php/lang/ast/unittest/TokensTest.class.php
+++ b/src/test/php/lang/ast/unittest/TokensTest.class.php
@@ -1,10 +1,11 @@
 <?php namespace lang\ast\unittest;
 
 use lang\FormatException;
-use lang\ast\Tokens;
+use lang\ast\{Language, Tokens};
 use unittest\{Assert, Expect, Test, Values};
 
 class TokensTest {
+  private $language;
 
   /**
    * Assertion helper
@@ -16,10 +17,15 @@ class TokensTest {
    */
   private function assertTokens($expected, $tokens) {
     $actual= [];
-    foreach ($tokens as $type => $value) {
-      $actual[]= [$type => $value[0]];
+    foreach ($tokens->iterator($this->language) as $token) {
+      $actual[]= [$token->kind => $token->value];
     }
     Assert::equals($expected, $actual);
+  }
+
+  #[Before]
+  public function language() {
+    $this->language= Language::named('PHP');
   }
 
   #[Test]
@@ -34,8 +40,7 @@ class TokensTest {
 
   #[Test, Expect(class: FormatException::class, withMessage: '/Unclosed string literal/'), Values(['"', "'", '"Test', "'Test"])]
   public function unclosed_string_literals($input) {
-    $t= (new Tokens($input))->getIterator(); 
-    $t->current();
+    (new Tokens($input))->iterator($this->language)->current();
   }
 
   #[Test, Values(['0', '1', '1_000_000_000'])]


### PR DESCRIPTION
The `lang.ast.Tokens` class now directly produces `lang.ast.Token` instances instead of yielding `$type => [$value, $line]`, which was then mapped inside the *Parse* class using an if/else cascade. 

This should be more memory-efficient and have a better performance, although the difference is probably marginal.