### PR TITLE
Syntactic support for PHP enums

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,6 +3,12 @@ XP AST ChangeLog
 
 ## ?.?.? / ????-??-??
 
+## 7.1.0 / ????-??-??
+
+* Merged PR #23: Add syntactic support for PHP 8.1 enums. Implementation
+  in the compiler is in pull request xp-framework/compiler#106
+  (@thekid)
+
 ## 7.0.4 / 2021-03-07
 
 * Fixed *Call to undefined method ::emitoperator()* caused by standalone

--- a/src/main/php/lang/ast/nodes/EnumCase.class.php
+++ b/src/main/php/lang/ast/nodes/EnumCase.class.php
@@ -2,7 +2,7 @@
 
 use lang\ast\Node;
 
-class EnumCase extends Node {
+class EnumCase extends Node implements Member {
   public $kind= 'enumcase';
   public $name;
 
@@ -10,4 +10,7 @@ class EnumCase extends Node {
     $this->name= $name;
     $this->line= $line;
   }
+
+  /** @return string */
+  public function lookup() { return $this->name; }
 }

--- a/src/main/php/lang/ast/nodes/EnumCase.class.php
+++ b/src/main/php/lang/ast/nodes/EnumCase.class.php
@@ -4,10 +4,11 @@ use lang\ast\Node;
 
 class EnumCase extends Node implements Member {
   public $kind= 'enumcase';
-  public $name;
+  public $name, $expression;
 
-  public function __construct($name, $line= -1) {
+  public function __construct($name, $expression, $line= -1) {
     $this->name= $name;
+    $this->expression= $expression;
     $this->line= $line;
   }
 

--- a/src/main/php/lang/ast/nodes/EnumCase.class.php
+++ b/src/main/php/lang/ast/nodes/EnumCase.class.php
@@ -1,14 +1,13 @@
 <?php namespace lang\ast\nodes;
 
-use lang\ast\Node;
-
-class EnumCase extends Node implements Member {
+class EnumCase extends Annotated implements Member {
   public $kind= 'enumcase';
   public $name, $expression;
 
-  public function __construct($name, $expression, $line= -1) {
+  public function __construct($name, $expression, $annotations, $line= -1) {
     $this->name= $name;
     $this->expression= $expression;
+    $this->annotations= $annotations;
     $this->line= $line;
   }
 

--- a/src/main/php/lang/ast/nodes/EnumCase.class.php
+++ b/src/main/php/lang/ast/nodes/EnumCase.class.php
@@ -13,4 +13,14 @@ class EnumCase extends Annotated implements Member {
 
   /** @return string */
   public function lookup() { return $this->name; }
+
+  /**
+   * Checks whether this node is of a given kind
+   *
+   * @param  string $kind
+   * @return bool
+   */
+  public function is($kind) {
+    return $this->kind === $kind || '@member' === $kind || parent::is($kind);
+  }
 }

--- a/src/main/php/lang/ast/nodes/EnumCase.class.php
+++ b/src/main/php/lang/ast/nodes/EnumCase.class.php
@@ -1,0 +1,13 @@
+<?php namespace lang\ast\nodes;
+
+use lang\ast\Node;
+
+class EnumCase extends Node {
+  public $kind= 'enumcase';
+  public $name;
+
+  public function __construct($name, $line= -1) {
+    $this->name= $name;
+    $this->line= $line;
+  }
+}

--- a/src/main/php/lang/ast/nodes/EnumDeclaration.class.php
+++ b/src/main/php/lang/ast/nodes/EnumDeclaration.class.php
@@ -4,15 +4,12 @@ use lang\ast\nodes\TypeDeclaration;
 
 class EnumDeclaration extends TypeDeclaration {
   public $kind= 'enum';
-  public $parent, $implements;
+  public $implements;
 
-  public function __construct($modifiers, $name, $parent= null, $implements= [], $body= [], $annotations= [], $comment= null, $line= -1) {
+  public function __construct($modifiers, $name, $implements= [], $body= [], $annotations= [], $comment= null, $line= -1) {
     parent::__construct($modifiers, $name, $body, $annotations, $comment, $line);
-    $this->parent= $parent;
     $this->implements= $implements;
   }
-
-  public function parent() { return $this->parent; }
 
   public function interfaces() { return $this->implements; }
 }

--- a/src/main/php/lang/ast/nodes/EnumDeclaration.class.php
+++ b/src/main/php/lang/ast/nodes/EnumDeclaration.class.php
@@ -1,0 +1,18 @@
+<?php namespace lang\ast\nodes;
+
+use lang\ast\nodes\TypeDeclaration;
+
+class EnumDeclaration extends TypeDeclaration {
+  public $kind= 'enum';
+  public $parent, $implements;
+
+  public function __construct($modifiers, $name, $parent= null, $implements= [], $body= [], $annotations= [], $comment= null, $line= -1) {
+    parent::__construct($modifiers, $name, $body, $annotations, $comment, $line);
+    $this->parent= $parent;
+    $this->implements= $implements;
+  }
+
+  public function parent() { return $this->parent; }
+
+  public function interfaces() { return $this->implements; }
+}

--- a/src/main/php/lang/ast/nodes/EnumDeclaration.class.php
+++ b/src/main/php/lang/ast/nodes/EnumDeclaration.class.php
@@ -13,4 +13,6 @@ class EnumDeclaration extends TypeDeclaration {
   }
 
   public function interfaces() { return $this->implements; }
+
+  public function case($name) { return $this->body[$name] ?? null; }
 }

--- a/src/main/php/lang/ast/nodes/EnumDeclaration.class.php
+++ b/src/main/php/lang/ast/nodes/EnumDeclaration.class.php
@@ -4,11 +4,12 @@ use lang\ast\nodes\TypeDeclaration;
 
 class EnumDeclaration extends TypeDeclaration {
   public $kind= 'enum';
-  public $implements;
+  public $base, $implements;
 
-  public function __construct($modifiers, $name, $implements= [], $body= [], $annotations= [], $comment= null, $line= -1) {
+  public function __construct($modifiers, $name, $base, $implements= [], $body= [], $annotations= [], $comment= null, $line= -1) {
     parent::__construct($modifiers, $name, $body, $annotations, $comment, $line);
     $this->implements= $implements;
+    $this->base= $base;
   }
 
   public function interfaces() { return $this->implements; }

--- a/src/main/php/lang/ast/syntax/PHP.class.php
+++ b/src/main/php/lang/ast/syntax/PHP.class.php
@@ -868,13 +868,6 @@ class PHP extends Language {
       $comment= $parse->comment;
       $parse->comment= null;
 
-      $parent= null;
-      if ('extends' === $parse->token->value) {
-        $parse->forward();
-        $parent= $parse->scope->resolve($parse->token->value);
-        $parse->forward();
-      }
-
       $implements= [];
       if ('implements' === $parse->token->value) {
         $parse->forward();
@@ -892,7 +885,7 @@ class PHP extends Language {
         } while (null !== $parse->token->value);
       }
       
-      $decl= new EnumDeclaration([], $name, $parent, $implements, [], [], $comment, $token->line);
+      $decl= new EnumDeclaration([], $name, $implements, [], [], $comment, $token->line);
       $parse->expecting('{', 'enum');
       $decl->body= $this->typeBody($parse, $decl->name);
       $parse->expecting('}', 'enum');

--- a/src/main/php/lang/ast/syntax/PHP.class.php
+++ b/src/main/php/lang/ast/syntax/PHP.class.php
@@ -909,9 +909,15 @@ class PHP extends Language {
       $name= $parse->token->value;
 
       $parse->forward();
+      if ('=' === $parse->token->value) {
+        $parse->forward();
+        $expr= $this->expression($parse, 0);
+      } else {
+        $expr= null;
+      }
       $parse->expecting(';', 'case');
 
-      $body[$name]= new EnumCase($name, $line);
+      $body[$name]= new EnumCase($name, $expr, $line);
       $body[$name]->holder= $holder;
     });
 

--- a/src/main/php/lang/ast/syntax/PHP.class.php
+++ b/src/main/php/lang/ast/syntax/PHP.class.php
@@ -884,8 +884,17 @@ class PHP extends Language {
           }
         } while (null !== $parse->token->value);
       }
-      
-      $decl= new EnumDeclaration([], $name, $implements, [], [], $comment, $token->line);
+
+      // Backed enums vs. unit enums
+      if (':' === $parse->token->value) {
+        $parse->forward();
+        $base= $parse->token->value;
+        $parse->forward();
+      } else {
+        $base= null;
+      }
+
+      $decl= new EnumDeclaration([], $name, $base, $implements, [], [], $comment, $token->line);
       $parse->expecting('{', 'enum');
       $decl->body= $this->typeBody($parse, $decl->name);
       $parse->expecting('}', 'enum');

--- a/src/main/php/lang/ast/syntax/PHP.class.php
+++ b/src/main/php/lang/ast/syntax/PHP.class.php
@@ -902,7 +902,7 @@ class PHP extends Language {
       return $decl;
     });
 
-    $this->body('case', function($parse, &$body, $annotations, $modifiers, $holder) {
+    $this->body('case', function($parse, &$body, $meta, $modifiers, $holder) {
       $line= $parse->token->line;
 
       $parse->forward();
@@ -917,11 +917,11 @@ class PHP extends Language {
       }
       $parse->expecting(';', 'case');
 
-      $body[$name]= new EnumCase($name, $expr, $line);
+      $body[$name]= new EnumCase($name, $expr, $meta[DETAIL_ANNOTATIONS] ?? [], $line);
       $body[$name]->holder= $holder;
     });
 
-    $this->body('use', function($parse, &$body, $annotations, $modifiers, $holder) {
+    $this->body('use', function($parse, &$body, $meta, $modifiers, $holder) {
       $line= $parse->token->line;
 
       $parse->forward();

--- a/src/main/php/lang/ast/syntax/PHP.class.php
+++ b/src/main/php/lang/ast/syntax/PHP.class.php
@@ -910,6 +910,7 @@ class PHP extends Language {
       $parse->expecting(';', 'case');
 
       $body[$name]= new EnumCase($name, $line);
+      $body[$name]->holder= $holder;
     });
 
     $this->body('use', function($parse, &$body, $annotations, $modifiers, $holder) {

--- a/src/main/php/lang/ast/syntax/PHP.class.php
+++ b/src/main/php/lang/ast/syntax/PHP.class.php
@@ -903,22 +903,30 @@ class PHP extends Language {
     });
 
     $this->body('case', function($parse, &$body, $meta, $modifiers, $holder) {
-      $line= $parse->token->line;
-
       $parse->forward();
-      $name= $parse->token->value;
+      do {
+        $line= $parse->token->line;
+        $name= $parse->token->value;
 
-      $parse->forward();
-      if ('=' === $parse->token->value) {
         $parse->forward();
-        $expr= $this->expression($parse, 0);
-      } else {
-        $expr= null;
-      }
-      $parse->expecting(';', 'case');
+        if ('=' === $parse->token->value) {
+          $parse->forward();
+          $expr= $this->expression($parse, 0);
+        } else {
+          $expr= null;
+        }
 
-      $body[$name]= new EnumCase($name, $expr, $meta[DETAIL_ANNOTATIONS] ?? [], $line);
-      $body[$name]->holder= $holder;
+        $body[$name]= new EnumCase($name, $expr, $meta[DETAIL_ANNOTATIONS] ?? [], $line);
+        $body[$name]->holder= $holder;
+
+        if (',' === $parse->token->value) {
+          $parse->forward();
+          continue;
+        } else {
+          $parse->expecting(';', 'case');
+          break;
+        }
+      } while ($parse->token->value);
     });
 
     $this->body('use', function($parse, &$body, $meta, $modifiers, $holder) {

--- a/src/test/php/lang/ast/unittest/parse/AttributesTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/AttributesTest.class.php
@@ -200,6 +200,11 @@ class AttributesTest extends ParseTest {
   }
 
   #[Test, Values('attributes')]
+  public function on_enum($attributes, $expected) {
+    $this->assertAnnotated($expected, $this->type($attributes.' enum T { }'));
+  }
+
+  #[Test, Values('attributes')]
   public function on_constant($attributes, $expected) {
     $type= $this->type('class T { '.$attributes.' const FIXTURE = 1; }');
     $this->assertAnnotated($expected, $type->constant('FIXTURE'));
@@ -221,5 +226,11 @@ class AttributesTest extends ParseTest {
   public function on_parameter($attributes, $expected) {
     $type= $this->type('class T { public function fixture('.$attributes.' $p) { } }');
     $this->assertAnnotated($expected, $type->method('fixture')->signature->parameters[0]);
+  }
+
+  #[Test, Values('attributes')]
+  public function on_enum_case($attributes, $expected) {
+    $type= $this->type('enum T { '.$attributes.' case ONE; }');
+    $this->assertAnnotated($expected, $type->case('ONE'));
   }
 }

--- a/src/test/php/lang/ast/unittest/parse/TypesTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/TypesTest.class.php
@@ -8,7 +8,8 @@ use lang\ast\nodes\{
   EnumCase,
   NamespaceDeclaration,
   TraitDeclaration,
-  UseExpression
+  UseExpression,
+  Literal
 };
 use unittest\{Assert, Expect, Test};
 
@@ -111,11 +112,19 @@ class TypesTest extends ParseTest {
   }
 
   #[Test]
-  public function enum_with_cases() {
+  public function unit_enum_with_cases() {
     $enum= new EnumDeclaration([], '\\A', null, [], [], [], null, self::LINE);
-    $enum->declare(new EnumCase('ONE', self::LINE));
-    $enum->declare(new EnumCase('TWO', self::LINE));
+    $enum->declare(new EnumCase('ONE', null, self::LINE));
+    $enum->declare(new EnumCase('TWO', null, self::LINE));
     $this->assertParsed([$enum], 'enum A { case ONE; case TWO; }');
+  }
+
+  #[Test]
+  public function backed_enum_with_cases() {
+    $enum= new EnumDeclaration([], '\\A', 'int', [], [], [], null, self::LINE);
+    $enum->declare(new EnumCase('ONE', new Literal('1', self::LINE), self::LINE));
+    $enum->declare(new EnumCase('TWO', new Literal('2', self::LINE), self::LINE));
+    $this->assertParsed([$enum], 'enum A: int { case ONE = 1; case TWO = 2; }');
   }
 
   #[Test]

--- a/src/test/php/lang/ast/unittest/parse/TypesTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/TypesTest.class.php
@@ -128,6 +128,14 @@ class TypesTest extends ParseTest {
   }
 
   #[Test]
+  public function unit_enum_with_grouped_cases() {
+    $enum= new EnumDeclaration([], '\\A', null, [], [], [], null, self::LINE);
+    $enum->declare(new EnumCase('ONE', null, [], self::LINE));
+    $enum->declare(new EnumCase('TWO', null, [], self::LINE));
+    $this->assertParsed([$enum], 'enum A { case ONE, TWO; }');
+  }
+
+  #[Test]
   public function class_with_trait() {
     $class= new ClassDeclaration([], '\\A', null, [], [], [], null, self::LINE);
     $class->body[]= new UseExpression(['\\B'], [], self::LINE);

--- a/src/test/php/lang/ast/unittest/parse/TypesTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/TypesTest.class.php
@@ -114,16 +114,16 @@ class TypesTest extends ParseTest {
   #[Test]
   public function unit_enum_with_cases() {
     $enum= new EnumDeclaration([], '\\A', null, [], [], [], null, self::LINE);
-    $enum->declare(new EnumCase('ONE', null, self::LINE));
-    $enum->declare(new EnumCase('TWO', null, self::LINE));
+    $enum->declare(new EnumCase('ONE', null, [], self::LINE));
+    $enum->declare(new EnumCase('TWO', null, [], self::LINE));
     $this->assertParsed([$enum], 'enum A { case ONE; case TWO; }');
   }
 
   #[Test]
   public function backed_enum_with_cases() {
     $enum= new EnumDeclaration([], '\\A', 'int', [], [], [], null, self::LINE);
-    $enum->declare(new EnumCase('ONE', new Literal('1', self::LINE), self::LINE));
-    $enum->declare(new EnumCase('TWO', new Literal('2', self::LINE), self::LINE));
+    $enum->declare(new EnumCase('ONE', new Literal('1', self::LINE), [], self::LINE));
+    $enum->declare(new EnumCase('TWO', new Literal('2', self::LINE), [], self::LINE));
     $this->assertParsed([$enum], 'enum A: int { case ONE = 1; case TWO = 2; }');
   }
 

--- a/src/test/php/lang/ast/unittest/parse/TypesTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/TypesTest.class.php
@@ -97,14 +97,14 @@ class TypesTest extends ParseTest {
   #[Test]
   public function empty_enum() {
     $this->assertParsed(
-      [new EnumDeclaration([], '\\A', null, [], [], [], null, self::LINE)],
+      [new EnumDeclaration([], '\\A', [], [], [], null, self::LINE)],
       'enum A { }'
     );
   }
 
   #[Test]
   public function enum_with_cases() {
-    $enum= new EnumDeclaration([], '\\A', null, [], [], [], null, self::LINE);
+    $enum= new EnumDeclaration([], '\\A', [], [], [], null, self::LINE);
     $enum->declare(new EnumCase('ONE', self::LINE));
     $enum->declare(new EnumCase('TWO', self::LINE));
     $this->assertParsed([$enum], 'enum A { case ONE; case TWO; }');

--- a/src/test/php/lang/ast/unittest/parse/TypesTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/TypesTest.class.php
@@ -95,16 +95,24 @@ class TypesTest extends ParseTest {
   }
 
   #[Test]
-  public function empty_enum() {
+  public function empty_unit_enum() {
     $this->assertParsed(
-      [new EnumDeclaration([], '\\A', [], [], [], null, self::LINE)],
+      [new EnumDeclaration([], '\\A', null, [], [], [], null, self::LINE)],
       'enum A { }'
     );
   }
 
   #[Test]
+  public function empty_backed_enum() {
+    $this->assertParsed(
+      [new EnumDeclaration([], '\\A', 'string', [], [], [], null, self::LINE)],
+      'enum A: string { }'
+    );
+  }
+
+  #[Test]
   public function enum_with_cases() {
-    $enum= new EnumDeclaration([], '\\A', [], [], [], null, self::LINE);
+    $enum= new EnumDeclaration([], '\\A', null, [], [], [], null, self::LINE);
     $enum->declare(new EnumCase('ONE', self::LINE));
     $enum->declare(new EnumCase('TWO', self::LINE));
     $this->assertParsed([$enum], 'enum A { case ONE; case TWO; }');

--- a/src/test/php/lang/ast/unittest/parse/TypesTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/TypesTest.class.php
@@ -1,7 +1,15 @@
 <?php namespace lang\ast\unittest\parse;
 
 use lang\ast\Errors;
-use lang\ast\nodes\{ClassDeclaration, InterfaceDeclaration, NamespaceDeclaration, TraitDeclaration, UseExpression};
+use lang\ast\nodes\{
+  ClassDeclaration,
+  InterfaceDeclaration,
+  EnumDeclaration,
+  EnumCase,
+  NamespaceDeclaration,
+  TraitDeclaration,
+  UseExpression
+};
 use unittest\{Assert, Expect, Test};
 
 class TypesTest extends ParseTest {
@@ -84,6 +92,22 @@ class TypesTest extends ParseTest {
       [new TraitDeclaration([], '\\A', [], [], null, self::LINE)],
       'trait A { }'
     );
+  }
+
+  #[Test]
+  public function empty_enum() {
+    $this->assertParsed(
+      [new EnumDeclaration([], '\\A', null, [], [], [], null, self::LINE)],
+      'enum A { }'
+    );
+  }
+
+  #[Test]
+  public function enum_with_cases() {
+    $enum= new EnumDeclaration([], '\\A', null, [], [], [], null, self::LINE);
+    $enum->body['ONE']= new EnumCase('ONE', self::LINE);
+    $enum->body['TWO']= new EnumCase('TWO', self::LINE);
+    $this->assertParsed([$enum], 'enum A { case ONE; case TWO; }');
   }
 
   #[Test]

--- a/src/test/php/lang/ast/unittest/parse/TypesTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/TypesTest.class.php
@@ -105,8 +105,8 @@ class TypesTest extends ParseTest {
   #[Test]
   public function enum_with_cases() {
     $enum= new EnumDeclaration([], '\\A', null, [], [], [], null, self::LINE);
-    $enum->body['ONE']= new EnumCase('ONE', self::LINE);
-    $enum->body['TWO']= new EnumCase('TWO', self::LINE);
+    $enum->declare(new EnumCase('ONE', self::LINE));
+    $enum->declare(new EnumCase('TWO', self::LINE));
     $this->assertParsed([$enum], 'enum A { case ONE; case TWO; }');
   }
 


### PR DESCRIPTION
See xp-framework/compiler#100

## Unit enums

```php
enum Suit {
  case Hearts;
  case Diamonds;
  case Clubs;
  case Spades;
}
```

* [x] Supported

## Backed enums

```php
enum Suit: string {
  case Hearts = 'H';
  case Diamonds = 'D';
  case Clubs = 'C';
  case Spades = 'S';
}
```

* [x] Supported

## Grouped syntax

```php
enum Direction {
  case Left, Right;
}
```

https://wiki.php.net/rfc/enumerations#grouped_syntax states that this "may cause syntactic issues with the planned addition of tagged unions", which are defined in https://wiki.php.net/rfc/tagged_unions and may be one of the following:

* `case None { }`
* `case Some(private mixed $value) { ... }`

...in addition to the existing declarations:

* `case ASC`
* `case DESC = 'desc'`

In none of these cases would a comma be ambiguous, therefore I think we might as well have it, thus allowing more concise syntax for enum declarations

* [x] Supported