### PR TITLE
Add support for `never` return type

### DIFF
--- a/src/main/php/lang/ast/Scope.class.php
+++ b/src/main/php/lang/ast/Scope.class.php
@@ -16,6 +16,7 @@ class Scope {
     'mixed'    => true,
     'array'    => true,
     'void'     => true,
+    'never'    => true,
     'resource' => true,
     'callable' => true,
     'iterable' => true,

--- a/src/main/php/lang/ast/syntax/PHP.class.php
+++ b/src/main/php/lang/ast/syntax/PHP.class.php
@@ -1086,6 +1086,7 @@ class PHP extends Language {
       'mixed'    => true,
       'array'    => true,
       'void'     => true,
+      'never'    => true,
       'resource' => true,
       'callable' => true,
       'iterable' => true,

--- a/src/test/php/lang/ast/unittest/TypeTest.class.php
+++ b/src/test/php/lang/ast/unittest/TypeTest.class.php
@@ -22,7 +22,7 @@ class TypeTest {
     ;
   }
 
-  #[Test, Values(['string', 'int', 'bool', 'mixed', 'float', 'array', 'object', 'resource', 'iterable', 'callable', 'double'])]
+  #[Test, Values(['string', 'int', 'bool', 'mixed', 'float', 'array', 'object', 'resource', 'iterable', 'callable', 'double', 'void', 'never'])]
   public function literals($t) {
     Assert::equals(new IsLiteral($t), $this->parse($t));
   }


### PR DESCRIPTION
See https://wiki.php.net/rfc/noreturn_type. Implements syntactic support for https://github.com/xp-framework/compiler/issues/109