### PR TITLE
Add support for declare construct

### DIFF
--- a/src/main/php/lang/ast/nodes/Directives.class.php
+++ b/src/main/php/lang/ast/nodes/Directives.class.php
@@ -1,0 +1,13 @@
+<?php namespace lang\ast\nodes;
+
+use lang\ast\Node;
+
+class Directives extends Node {
+  public $kind= 'block';
+  public $declare;
+
+  public function __construct($declare, $line= -1) {
+    $this->declare= $declare;
+    $this->line= $line;
+  }
+}

--- a/src/main/php/lang/ast/nodes/Directives.class.php
+++ b/src/main/php/lang/ast/nodes/Directives.class.php
@@ -3,7 +3,7 @@
 use lang\ast\Node;
 
 class Directives extends Node {
-  public $kind= 'block';
+  public $kind= 'directives';
   public $declare;
 
   public function __construct($declare, $line= -1) {

--- a/src/main/php/lang/ast/syntax/PHP.class.php
+++ b/src/main/php/lang/ast/syntax/PHP.class.php
@@ -12,6 +12,7 @@ use lang\ast\nodes\{
   ClosureExpression,
   Constant,
   ContinueStatement,
+  Directives,
   DoLoop,
   EchoStatement,
   EnumCase,
@@ -512,6 +513,24 @@ class PHP extends Language {
 
       $parse->forward();
       return $this->statement($parse);
+    });
+
+    $this->stmt('declare', function($parse, $token) {
+      $parse->expecting('(', 'declare');
+
+      $declare= [];
+      while (')' !== $parse->token->value) {
+        $name= $parse->token->value;
+        $parse->forward();
+        $parse->expecting('=', 'declare');
+        $declare[$name]= $this->expression($parse, 0);
+
+        if (')' === $parse->token->value) break;
+        $parse->expecting(',', 'declare');        
+      }
+
+      $parse->expecting(')', 'declare');
+      return new Directives($declare, $token->line);
     });
 
     $this->stmt('{', function($parse, $token) {

--- a/src/test/php/lang/ast/unittest/parse/StartTokensTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/StartTokensTest.class.php
@@ -1,7 +1,7 @@
 <?php namespace lang\ast\unittest\parse;
 
 use lang\ast\Errors;
-use lang\ast\nodes\NamespaceDeclaration;
+use lang\ast\nodes\{NamespaceDeclaration, Directives, Literal};
 use unittest\{Assert, Test};
 
 class StartTokensTest extends ParseTest {
@@ -11,6 +11,24 @@ class StartTokensTest extends ParseTest {
     $this->assertParsed(
       [new NamespaceDeclaration('test', self::LINE)],
       '<?php namespace test;'
+    );
+  }
+
+  #[Test]
+  public function declare() {
+    $declare= ['strict_types' => new Literal('1', self::LINE)];
+    $this->assertParsed(
+      [new Directives($declare, self::LINE)],
+      '<?php declare(strict_types = 1);'
+    );
+  }
+
+  #[Test]
+  public function declare_with_multiple() {
+    $declare= ['strict_types' => new Literal('1', self::LINE), 'encoding' => new Literal('"UTF-8"', self::LINE)];
+    $this->assertParsed(
+      [new Directives($declare, self::LINE)],
+      '<?php declare(strict_types = 1, encoding = "UTF-8");'
     );
   }
 


### PR DESCRIPTION
...e.g.:

```php
declare(strict_types = 1);
```

See https://www.php.net/manual/en/control-structures.declare.php