### PR TITLE
Parse argument lists into placeholders and arguments

### DIFF
--- a/src/main/php/lang/ast/nodes/PartialExpression.class.php
+++ b/src/main/php/lang/ast/nodes/PartialExpression.class.php
@@ -1,0 +1,17 @@
+<?php namespace lang\ast\nodes;
+
+use lang\ast\Node;
+
+class PartialExpression extends Node {
+  public $kind= 'partial';
+  public $placeholders, $invocation;
+
+  public function __construct($placeholders, $invocation, $line= -1) {
+    $this->placeholders= $placeholders;
+    $this->invocation= $invocation;
+    $this->line= $line;
+  }
+
+  /** @return iterable */
+  public function children() { return [$this->invocation]; }
+}


### PR DESCRIPTION
```php
// Parsed into new InvokeExpression(new Literal('strlen'), [new Literal('"Test"')])
// Returns int(4)
strlen('Test'); 

// Parsed into new PartialExpression([0 => false], new InvokeExpression(new Literal('strlen'), [null])
// Returns a closure equivalent to fn($_0) => strlen($_0)
strlen(?); 

// Parsed into new PartialExpression([0 => true], new InvokeExpression(new Literal('strlen'), [null])
// Returns a closure equivalent to fn(... $_0) => strlen(...$_0)
strlen(...);
```

See https://wiki.php.net/rfc/partial_function_application