### PR TITLE
Implement first-class callable syntax

### DIFF
--- a/src/main/php/lang/ast/nodes/CallableExpression.class.php
+++ b/src/main/php/lang/ast/nodes/CallableExpression.class.php
@@ -1,0 +1,16 @@
+<?php namespace lang\ast\nodes;
+
+use lang\ast\Node;
+
+class CallableExpression extends Node {
+  public $kind= 'callable';
+  public $expression;
+
+  public function __construct($expression, $line= -1) {
+    $this->expression= $expression;
+    $this->line= $line;
+  }
+
+  /** @return iterable */
+  public function children() { return [$this->expression]; }
+}

--- a/src/main/php/lang/ast/nodes/ScopeExpression.class.php
+++ b/src/main/php/lang/ast/nodes/ScopeExpression.class.php
@@ -13,6 +13,7 @@ class ScopeExpression extends Node {
   }
 
   /** @return iterable */
-  public function children() { return [$this->member]; }
-
+  public function children() {
+    return $this->type instanceof parent ? [$this->type, $this->member] : [$this->member];
+  }
 }

--- a/src/main/php/lang/ast/syntax/PHP.class.php
+++ b/src/main/php/lang/ast/syntax/PHP.class.php
@@ -168,6 +168,7 @@ class PHP extends Language {
           $dots= $parse->token;
           $parse->forward();
           if (')' === $parse->token->value) {
+            $parse->forward();
             return new CallableExpression(new ScopeExpression($scope, $expr, $token->line), $token->line);
           }
 
@@ -191,6 +192,7 @@ class PHP extends Language {
         $dots= $parse->token;
         $parse->forward();
         if (')' === $parse->token->value) {
+          $parse->forward();
           return new CallableExpression($left, $token->line);
         }
 

--- a/src/main/php/lang/ast/syntax/PHP.class.php
+++ b/src/main/php/lang/ast/syntax/PHP.class.php
@@ -1114,8 +1114,9 @@ class PHP extends Language {
       $expr= new Literal($parse->token->value, $parse->token->line);
       $parse->forward();
     } else {
-      $parse->expecting('name or variable', 'member');
-      $expr= null;
+      $parse->expecting('an expression in curly braces, a name or a variable', 'member');
+      $expr= new Literal($parse->token->value, $parse->token->line);
+      $parse->forward();
     }
     return $expr;
   }

--- a/src/test/php/lang/ast/unittest/parse/InvokeTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/InvokeTest.class.php
@@ -1,6 +1,6 @@
 <?php namespace lang\ast\unittest\parse;
 
-use lang\ast\nodes\{InstanceExpression, InvokeExpression, Literal, Variable};
+use lang\ast\nodes\{CallableExpression, InstanceExpression, InvokeExpression, UnpackExpression, ScopeExpression, Literal, Variable};
 use unittest\{Assert, Test};
 
 /**
@@ -60,6 +60,31 @@ class InvokeTest extends ParseTest {
     $this->assertParsed(
       [new InvokeExpression(new Literal('test', self::LINE), $arguments, self::LINE)],
       'test(1, named: 2);'
+    );
+  }
+
+  #[Test]
+  public function argument_unpacking() {
+    $unpack= new UnpackExpression(new Variable('it', self::LINE), self::LINE);
+    $this->assertParsed(
+      [new InvokeExpression(new Literal('func', self::LINE), [$unpack], self::LINE)],
+      'func(...$it);'
+    );
+  }
+
+  #[Test]
+  public function first_class_callable_function() {
+    $this->assertParsed(
+      [new CallableExpression(new Literal('strlen', self::LINE), self::LINE)],
+      'strlen(...);'
+    );
+  }
+
+  #[Test]
+  public function first_class_callable_static() {
+    $this->assertParsed(
+      [new CallableExpression(new ScopeExpression('self', new Literal('length', self::LINE), self::LINE), self::LINE)],
+      'self::length(...);'
     );
   }
 }

--- a/src/test/php/lang/ast/unittest/parse/MembersTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/MembersTest.class.php
@@ -126,12 +126,20 @@ class MembersTest extends ParseTest {
   public function dynamic_instance_property_access_via_variable() {
     $this->assertParsed(
       [new InstanceExpression(new Variable('a', self::LINE), new Variable('member', self::LINE), self::LINE)],
+      '$a->$member;'
+    );
+  }
+
+  #[Test]
+  public function dynamic_instance_property_access_via_variable_expression() {
+    $this->assertParsed(
+      [new InstanceExpression(new Variable('a', self::LINE), new Variable('member', self::LINE), self::LINE)],
       '$a->{$member};'
     );
   }
 
   #[Test]
-  public function dynamic_instance_property_access_via_expression() {
+  public function dynamic_instance_property_access_via_complex_expression() {
     $member= new InvokeExpression(
       new InstanceExpression(new Variable('field', self::LINE), new Literal('get', self::LINE), self::LINE),
       [new Variable('instance', self::LINE)],


### PR DESCRIPTION
Example:

```php
// Parsed into new CallableExpression(new Literal('strlen'))
strlen(...);

// Parsed into new CallableExpression(new ScopeExpression('Enum', new Literal('valueOf')))
Enum::valueOf(...);

// Parsed into new CallableExpression(new InstanceExpression(new Variable('this'), new Literal('run')))
$this->run(...);
```

See https://wiki.php.net/rfc/first_class_callable_syntax