### PR TITLE
Intersection types

### DIFF
--- a/src/main/php/lang/ast/types/IsArray.class.php
+++ b/src/main/php/lang/ast/types/IsArray.class.php
@@ -8,9 +8,9 @@ class IsArray extends Type {
   /**
    * Creates a new type
    *
-   * @param  self[] $component
+   * @param  parent $component
    */
-  public function __construct($component= []) {
+  public function __construct($component) {
     $this->component= $component;
   }
 

--- a/src/main/php/lang/ast/types/IsIntersection.class.php
+++ b/src/main/php/lang/ast/types/IsIntersection.class.php
@@ -1,0 +1,28 @@
+<?php namespace lang\ast\types;
+
+use lang\ast\Type;
+
+class IsIntersection extends Type {
+  public $components;
+
+  /**
+   * Creates a new type
+   *
+   * @param  parent[] $components
+   */
+  public function __construct($components= []) {
+    $this->components= $components;
+  }
+
+  /** @return string */
+  public function literal() { return literal($this->name()); }
+
+  /** @return string */
+  public function name() {
+    $n= '';
+    foreach ($this->components as $type) {
+      $n.= '&'.$type->name();
+    }
+    return substr($n, 1);
+  }
+}

--- a/src/test/php/lang/ast/unittest/parse/TypeParsingTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/TypeParsingTest.class.php
@@ -1,0 +1,114 @@
+<?php namespace lang\ast\unittest\parse;
+
+use lang\ast\types\{IsLiteral, IsArray, IsMap, IsValue, IsFunction, IsGeneric, IsUnion, IsIntersection};
+use lang\ast\{Language, Parse, Tokens};
+use unittest\{Assert, Test, Values};
+
+class TypeParsingTest {
+
+  /**
+   * Parses a type from a given string
+   *
+   * @param  string $type
+   * @param  lang.ast.Type
+   */
+  private function parse($type) {
+    $language= Language::named('PHP');
+    $parse= new Parse($language, new Tokens($type, static::class), null);
+    $parse->forward();
+    return $language->type($parse);
+  }
+
+  /** @return iterable */
+  private function arrays() {
+    yield ['array<string>', new IsLiteral('string')];
+    yield ['array<Value>', new IsValue('Value')];
+    yield ['array<array<int>>', new IsArray(new IsLiteral('int'))];
+  }
+
+  /** @return iterable */
+  private function maps() {
+    yield ['array<string, Value>', new IsLiteral('string'), new IsValue('Value')];
+    yield ['array<string, array<int>>', new IsLiteral('string'), new IsArray(new IsLiteral('int'))];
+    yield ['array<string, array<string, mixed>>', new IsLiteral('string'), new IsMap(new IsLiteral('string'), new IsLiteral('mixed'))];
+  }
+
+  /** @return iterable */
+  private function generics() {
+    yield ['Vector<string>', 'Vector', [new IsLiteral('string')]];
+    yield ['Map<string, Value>', 'Map', [new IsLiteral('string'), new IsLiteral('Value')]];
+    yield ['Map<string, Vector<int>>', 'Map', [new IsLiteral('string'), new IsGeneric('Vector', [new IsLiteral('int')])]];
+  }
+
+  /** @return iterable */
+  private function functions() {
+    yield ['function(): void', [], new IsLiteral('void')];
+    yield ['function(string): string', [new IsLiteral('string')], new IsLiteral('string')];
+    yield ['function(int, int): int', [new IsLiteral('int'), new IsLiteral('int')], new IsLiteral('int')];
+  }
+
+  /** @return iterable */
+  private function unions() {
+    yield ['int|string', [new IsLiteral('int'), new IsLiteral('string')]];
+    yield ['string|File|URI', [new IsLiteral('string'), new IsValue('File'), new IsValue('URI')]];
+  }
+
+  /** @return iterable */
+  private function intersections() {
+    yield ['Countable&Traversable', [new IsValue('Countable'), new IsValue('Traversable')]];
+    yield ['Countable&Traversable&Throwable', [new IsValue('Countable'), new IsValue('Traversable'), new IsValue('Throwable')]];
+  }
+
+  #[Test, Values(['string', 'int', 'bool', 'float', 'void', 'never', 'array', 'object', 'callable', 'iterable', 'mixed'])]
+  public function literal_type($type) {
+    Assert::equals(new IsLiteral($type), $this->parse($type));
+  }
+
+  #[Test, Values(['Value', '\Error', '\lang\Value'])]
+  public function value_type($type) {
+    Assert::equals(new IsValue($type), $this->parse($type));
+  }
+
+  #[Test, Values('arrays')]
+  public function array_type($type, $component) {
+    Assert::equals(new IsArray($component), $this->parse($type));
+  }
+
+  #[Test, Values('maps')]
+  public function map_type($type, $key, $value) {
+    Assert::equals(new IsMap($key, $value), $this->parse($type));
+  }
+
+  #[Test, Values('generics')]
+  public function generic_type($type, $base, $components) {
+    Assert::equals(new IsGeneric($base, $components), $this->parse($type));
+  }
+
+  #[Test, Values('functions')]
+  public function function_type($type, $arguments, $returns) {
+    Assert::equals(new IsFunction($arguments, $returns), $this->parse($type));
+  }
+
+  #[Test, Values('unions')]
+  public function union_type($type, $components) {
+    Assert::equals(new IsUnion($components), $this->parse($type));
+  }
+
+  #[Test, Values('intersections')]
+  public function intersection_type($type, $components) {
+    Assert::equals(new IsIntersection($components), $this->parse($type));
+  }
+
+  #[Test]
+  public function value_with_byref_param() {
+    Assert::equals(new IsValue('Countable'), $this->parse('Countable &$param'));
+  }
+
+  #[Test]
+  public function intersection_with_byref_param() {
+    Assert::equals(
+      new IsIntersection([new IsValue('Countable'), new IsValue('Traversable')]),
+      $this->parse('Countable&Traversable &$param')
+    );
+  }
+}

--- a/src/test/php/lang/ast/unittest/parse/TypeParsingTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/TypeParsingTest.class.php
@@ -67,43 +67,43 @@ class TypeParsingTest {
   }
 
   #[Test, Values(['string', 'int', 'bool', 'float', 'void', 'never', 'array', 'object', 'callable', 'iterable', 'mixed'])]
-  public function literal_type($type) {
-    Assert::equals(new IsLiteral($type), $this->parse($type));
+  public function literal_type($declaration) {
+    Assert::equals(new IsLiteral($declaration), $this->parse($declaration));
   }
 
   #[Test, Values(['Value', '\Error', '\lang\Value'])]
-  public function value_type($type) {
-    Assert::equals(new IsValue($type), $this->parse($type));
+  public function value_type($declaration) {
+    Assert::equals(new IsValue($declaration), $this->parse($declaration));
   }
 
   #[Test, Values('arrays')]
-  public function array_type($type, $component) {
-    Assert::equals(new IsArray($component), $this->parse($type));
+  public function array_type($declaration, $component) {
+    Assert::equals(new IsArray($component), $this->parse($declaration));
   }
 
   #[Test, Values('maps')]
-  public function map_type($type, $key, $value) {
-    Assert::equals(new IsMap($key, $value), $this->parse($type));
+  public function map_type($declaration, $key, $value) {
+    Assert::equals(new IsMap($key, $value), $this->parse($declaration));
   }
 
   #[Test, Values('generics')]
-  public function generic_type($type, $base, $components) {
-    Assert::equals(new IsGeneric($base, $components), $this->parse($type));
+  public function generic_type($declaration, $base, $components) {
+    Assert::equals(new IsGeneric($base, $components), $this->parse($declaration));
   }
 
   #[Test, Values('functions')]
-  public function function_type($type, $arguments, $returns) {
-    Assert::equals(new IsFunction($arguments, $returns), $this->parse($type));
+  public function function_type($declaration, $arguments, $returns) {
+    Assert::equals(new IsFunction($arguments, $returns), $this->parse($declaration));
   }
 
   #[Test, Values('unions')]
-  public function union_type($type, $components) {
-    Assert::equals(new IsUnion($components), $this->parse($type));
+  public function union_type($declaration, $components) {
+    Assert::equals(new IsUnion($components), $this->parse($declaration));
   }
 
   #[Test, Values('intersections')]
-  public function intersection_type($type, $components) {
-    Assert::equals(new IsIntersection($components), $this->parse($type));
+  public function intersection_type($declaration, $components) {
+    Assert::equals(new IsIntersection($components), $this->parse($declaration));
   }
 
   #[Test, Values('nullables')]

--- a/src/test/php/lang/ast/unittest/parse/TypeParsingTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/TypeParsingTest.class.php
@@ -1,6 +1,6 @@
 <?php namespace lang\ast\unittest\parse;
 
-use lang\ast\types\{IsLiteral, IsArray, IsMap, IsValue, IsFunction, IsGeneric, IsUnion, IsIntersection};
+use lang\ast\types\{IsLiteral, IsArray, IsMap, IsValue, IsFunction, IsGeneric, IsNullable, IsUnion, IsIntersection};
 use lang\ast\{Language, Parse, Tokens};
 use unittest\{Assert, Test, Values};
 
@@ -59,6 +59,13 @@ class TypeParsingTest {
     yield ['Countable&Traversable&Throwable', [new IsValue('Countable'), new IsValue('Traversable'), new IsValue('Throwable')]];
   }
 
+  /** @return iterable */
+  private function nullables() {
+    yield ['?Countable', new IsValue('Countable')];
+    yield ['?string|int', new IsUnion([new IsLiteral('string'), new IsLiteral('int')])];
+    yield ['?Countable&Traversable', new IsIntersection([new IsValue('Countable'), new IsValue('Traversable')])];
+  }
+
   #[Test, Values(['string', 'int', 'bool', 'float', 'void', 'never', 'array', 'object', 'callable', 'iterable', 'mixed'])]
   public function literal_type($type) {
     Assert::equals(new IsLiteral($type), $this->parse($type));
@@ -97,6 +104,11 @@ class TypeParsingTest {
   #[Test, Values('intersections')]
   public function intersection_type($type, $components) {
     Assert::equals(new IsIntersection($components), $this->parse($type));
+  }
+
+  #[Test, Values('nullables')]
+  public function nullable_type($declaration, $type) {
+    Assert::equals(new IsNullable($type), $this->parse($declaration));
   }
 
   #[Test]


### PR DESCRIPTION
Implements syntactic support for intersection types:

```php
function fixture(Countable&Traversable $t) { ... }
```

See https://github.com/xp-framework/compiler/issues/117 and https://wiki.php.net/rfc/pure-intersection-types