### PR TITLE
Add error source (file and line) to message

### DIFF
--- a/src/main/php/lang/ast/Errors.class.php
+++ b/src/main/php/lang/ast/Errors.class.php
@@ -17,20 +17,20 @@ class Errors extends IllegalStateException {
         throw new IllegalArgumentException('Errors may not be empty!');
 
       case 1:
-        $message= $errors[0]->getMessage();
+        $message= $errors[0]->message.' [line '.$errors[0]->line.' of '.$errors[0]->file.']';
         break;
 
       default: 
         $message= "Errors {\n";
         foreach ($errors as $error) {
-          $message.= '  '.$error->message.' at line '.$error->line."\n";
+          $message.= '  '.$error->message.' [line '.$error->line.' of '.$error->file."]\n";
         }
         $message.= '}';
     }
 
     parent::__construct($message);
     $this->file= $file;
-    $this->line= $errors[0]->getLine();
+    $this->line= $errors[0]->line;
   }
 
   /**

--- a/src/test/php/lang/ast/unittest/parse/ErrorsTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/ErrorsTest.class.php
@@ -17,7 +17,7 @@ class ErrorsTest extends ParseTest {
       $parse->tree();
       throw new AssertionFailedError('No exception raised');
     } catch (Errors $expected) {
-      Assert::equals($message, $expected->getMessage());
+      Assert::equals($message.' [line 1 of '.self::class.']', $expected->getMessage());
     }
   }
 


### PR DESCRIPTION
## Before

```
Errors {
  Expected ")", have "int" in braced at line 6
  Missing semicolon after braced statement at line 6
  Unexpected ) at line 6
  Missing semicolon after variable statement at line 6
  Missing semicolon after assignment statement at line 17
  Unexpected (end) at line 1
}
```

## After 

```
Errors {
  Expected ")", have "int" in braced [line 6 of Stream.php]
  Missing semicolon after braced statement [line 6 of Stream.php]
  Unexpected ) [line 6 of Stream.php]
  Missing semicolon after variable statement [line 6 of Stream.php]
  Missing semicolon after assignment statement [line 17 of Stream.php]
  Unexpected (end) [line 1 of Stream.php]
}
```