### PR TITLE
Support `new T(...)` callable syntax

### DIFF
--- a/src/main/php/lang/ast/nodes/CallableNewExpression.class.php
+++ b/src/main/php/lang/ast/nodes/CallableNewExpression.class.php
@@ -1,0 +1,16 @@
+<?php namespace lang\ast\nodes;
+
+use lang\ast\Node;
+
+class CallableNewExpression extends Node {
+  public $kind= 'callablenew';
+  public $type;
+
+  public function __construct($type, $line= -1) {
+    $this->type= $type;
+    $this->line= $line;
+  }
+
+  /** @return iterable */
+  public function children() { return [$this->type]; }
+}

--- a/src/main/php/lang/ast/syntax/PHP.class.php
+++ b/src/main/php/lang/ast/syntax/PHP.class.php
@@ -6,6 +6,7 @@ use lang\ast\nodes\{
   Braced,
   BreakStatement,
   CallableExpression,
+  CallableNewExpression,
   CaseLabel,
   CastExpression,
   CatchStatement,
@@ -330,16 +331,15 @@ class PHP extends Language {
         if (')' === $parse->token->value) {
           $parse->forward();
 
-          $arguments= [new UnpackExpression(new Variable('__args'), $token->line)];
           if (null === $type) {
             $class= $this->clazz($parse, null);
             $class->annotations= $annotations;
-            $new= new NewClassExpression($class, $arguments, $token->line);
+            $new= new NewClassExpression($class, null, $token->line);
           } else {
-            $new= new NewExpression($type, $arguments, $token->line);
+            $new= new NewExpression($type, null, $token->line);
           }
 
-          return new CallableExpression($new, $token->line);
+          return new CallableNewExpression($new, $token->line);
         }
 
         $parse->queue[]= $parse->token;

--- a/src/test/php/lang/ast/unittest/parse/InvokeTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/InvokeTest.class.php
@@ -2,6 +2,7 @@
 
 use lang\ast\nodes\{
   CallableExpression,
+  CallableNewExpression,
   NewExpression,
   InstanceExpression,
   InvokeExpression,
@@ -99,9 +100,8 @@ class InvokeTest extends ParseTest {
 
   #[Test]
   public function first_class_callable_object_creation() {
-    $args= [new UnpackExpression(new Variable('__args'), self::LINE)];
     $this->assertParsed(
-      [new CallableExpression(new NewExpression('\\T', $args, self::LINE), self::LINE)],
+      [new CallableNewExpression(new NewExpression('\\T', null, self::LINE), self::LINE)],
       'new T(...);'
     );
   }

--- a/src/test/php/lang/ast/unittest/parse/InvokeTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/InvokeTest.class.php
@@ -1,6 +1,15 @@
 <?php namespace lang\ast\unittest\parse;
 
-use lang\ast\nodes\{CallableExpression, InstanceExpression, InvokeExpression, UnpackExpression, ScopeExpression, Literal, Variable};
+use lang\ast\nodes\{
+  CallableExpression,
+  NewExpression,
+  InstanceExpression,
+  InvokeExpression,
+  UnpackExpression,
+  ScopeExpression,
+  Literal,
+  Variable
+};
 use unittest\{Assert, Test};
 
 /**
@@ -85,6 +94,15 @@ class InvokeTest extends ParseTest {
     $this->assertParsed(
       [new CallableExpression(new ScopeExpression('self', new Literal('length', self::LINE), self::LINE), self::LINE)],
       'self::length(...);'
+    );
+  }
+
+  #[Test]
+  public function first_class_callable_object_creation() {
+    $args= [new UnpackExpression(new Variable('__args'), self::LINE)];
+    $this->assertParsed(
+      [new CallableExpression(new NewExpression('\\T', $args, self::LINE), self::LINE)],
+      'new T(...);'
     );
   }
 }


### PR DESCRIPTION
* [x] New `lang.ast.nodes.CallableNewExpression` node
* [x] Parse into these containing `NewExpression` or `NewClassExpression` nodes with *null* args in their *type* member
* [x] Parsing test