### PR TITLE
Refactor apidoc comments from bare strings to Comment instances

### DIFF
--- a/src/main/php/lang/ast/Parse.class.php
+++ b/src/main/php/lang/ast/Parse.class.php
@@ -1,5 +1,7 @@
 <?php namespace lang\ast;
 
+use lang\ast\nodes\Comment;
+
 /** A parsing operation for streaming and access via parse tree */
 class Parse {
   private $tokens;
@@ -54,8 +56,6 @@ class Parse {
    * @return void
    */
   public function forward() {
-    static $line= 1;
-
     if ($this->queue) {
       $this->token= array_shift($this->queue);
       return;
@@ -66,17 +66,16 @@ class Parse {
       $this->tokens->next();
 
       // Store apidoc comments, then continue to next token
-      if ('comment' === $this->token->kind) {
-        if ('/' === $this->token->value[0] && '*' === $this->token->value[2] ?? null) {
-          $this->comment= $this->token->value;
+      if (null === $this->token->symbol) {
+        if ('apidoc' === $this->token->kind) {
+          $this->comment= new Comment($this->token->value, $this->token->line);
         }
         continue;
       }
-
       return;
     }
 
-    $this->token= new Token($this->language->symbol('(end)'), null, null, $line);
+    $this->token= new Token($this->language->symbol('(end)'), null, null, $this->token ? $this->token->line : 1);
   }
 
   /**

--- a/src/main/php/lang/ast/Tokens.class.php
+++ b/src/main/php/lang/ast/Tokens.class.php
@@ -156,7 +156,7 @@ class Tokens {
               $comment.= $chunk;
             } while (null !== $chunk && '*' !== $chunk[strlen($chunk) - 1]);
             $comment.= $next('/');
-            yield new Token(null, 'comment', '/*'.$comment, $line);
+            yield new Token(null, '*' === $comment[0] ? 'apidoc' : 'comment', '/*'.$comment, $line);
             $line+= substr_count($comment, "\n");
             continue;
           }

--- a/src/main/php/lang/ast/nodes/Annotated.class.php
+++ b/src/main/php/lang/ast/nodes/Annotated.class.php
@@ -4,6 +4,27 @@ use lang\ast\Node;
 
 abstract class Annotated extends Node {
   public $annotations;
+  public $comment= null;
+
+  /**
+   * Attach a comment and modify line to include the comment.
+   *
+   * @param  lang.ast.nodes.Comment|string $comment
+   * @return self
+   */
+  public function attach($comment) {
+    if ('' === $comment) {
+      $this->comment= null;
+    } else if ($comment instanceof Comment) {
+      $this->comment= $comment->ending($this->line);
+      $this->line= $comment->line;
+    } else {
+      $declaration= '/' === $comment[0] ? $comment : '/** '.str_replace("\n", "\n * ", $comment).' */';
+      $this->comment= new Comment($declaration, $this->line);
+      $this->line+= substr_count($comment, "\n") + 1;
+    }
+    return $this;
+  }
 
   /**
    * Returns an annotation for a given name, or NULL if no annotation

--- a/src/main/php/lang/ast/nodes/Annotated.class.php
+++ b/src/main/php/lang/ast/nodes/Annotated.class.php
@@ -23,7 +23,7 @@ abstract class Annotated extends Node {
       $this->comment= new Comment($declaration, $this->line);
       $this->line+= substr_count($comment, "\n") + 1;
     }
-    }
+  }
 
   /**
    * Returns an annotation for a given name, or NULL if no annotation

--- a/src/main/php/lang/ast/nodes/Annotated.class.php
+++ b/src/main/php/lang/ast/nodes/Annotated.class.php
@@ -16,7 +16,7 @@ abstract class Annotated extends Node {
     if ('' === $comment) {
       $this->comment= null;
     } else if ($comment instanceof Comment) {
-      $this->comment= $comment->ending($this->line);
+      $this->comment= $comment;
       $this->line= $comment->line;
     } else {
       $declaration= '/' === $comment[0] ? $comment : '/** '.str_replace("\n", "\n * ", $comment).' */';

--- a/src/main/php/lang/ast/nodes/Annotated.class.php
+++ b/src/main/php/lang/ast/nodes/Annotated.class.php
@@ -10,7 +10,7 @@ abstract class Annotated extends Node {
    * Attach a comment and modify line to include the comment.
    *
    * @param  lang.ast.nodes.Comment|string $comment
-   * @return self
+   * @return void
    */
   public function attach($comment) {
     if ('' === $comment) {
@@ -23,8 +23,7 @@ abstract class Annotated extends Node {
       $this->comment= new Comment($declaration, $this->line);
       $this->line+= substr_count($comment, "\n") + 1;
     }
-    return $this;
-  }
+    }
 
   /**
    * Returns an annotation for a given name, or NULL if no annotation

--- a/src/main/php/lang/ast/nodes/Comment.class.php
+++ b/src/main/php/lang/ast/nodes/Comment.class.php
@@ -8,7 +8,6 @@ use lang\ast\Node;
 class Comment extends Node implements ArrayAccess {
   public $kind= 'comment';
   public $declaration;
-  public $end= null;
 
   /**
    * Creates a new comment
@@ -19,17 +18,6 @@ class Comment extends Node implements ArrayAccess {
   public function __construct($declaration= '', $line= -1) {
     $this->declaration= $declaration;
     $this->line= $line;
-  }
-
-  /**
-   * Sets comment end line
-   *
-   * @param  int $end
-   * @return self
-   */
-  public function ending($end) {
-    $this->end= $end;
-    return $this;
   }
 
   #[ReturnTypeWillChange]

--- a/src/main/php/lang/ast/nodes/Comment.class.php
+++ b/src/main/php/lang/ast/nodes/Comment.class.php
@@ -1,45 +1,32 @@
 <?php namespace lang\ast\nodes;
 
-use ArrayAccess, ReturnTypeWillChange;
-use lang\IllegalAccessException;
 use lang\ast\Node;
 
-/** Comment */
-class Comment extends Node implements ArrayAccess {
+class Comment extends Node {
   public $kind= 'comment';
   public $declaration;
 
   /**
    * Creates a new comment
    *
-   * @param  string $declaration including slashes and asterisks
-   * @param  int $line
+   * @param string $declaration including slashes and asterisks
+   * @param int $line
    */
   public function __construct($declaration= '', $line= -1) {
     $this->declaration= $declaration;
     $this->line= $line;
   }
 
-  #[ReturnTypeWillChange]
-  public function offsetExists($i) {
-    return $i >= 0 && $i < strlen($this->declaration);
+  /**
+   * Returns contents stripped of all slashes and asterisks.
+   *
+   * @return string
+   */
+  public function content() {
+    return trim(preg_replace('/\n\s+\* ?/', "\n", substr($this->declaration, 3, -2)));
   }
 
-  #[ReturnTypeWillChange]
-  public function offsetGet($i) {
-    return $this->declaration[$i] ?? null;
-  }
-
-  #[ReturnTypeWillChange]
-  public function offsetSet($i, $value) {
-    throw new IllegalAccessException('Cannot modify comment');
-  }
-
-  #[ReturnTypeWillChange]
-  public function offsetUnset($i) {
-    throw new IllegalAccessException('Cannot modify comment');
-  }
-
+  /** @return string */
   public function __toString() {
     return $this->declaration;
   }

--- a/src/main/php/lang/ast/nodes/Comment.class.php
+++ b/src/main/php/lang/ast/nodes/Comment.class.php
@@ -1,0 +1,58 @@
+<?php namespace lang\ast\nodes;
+
+use ArrayAccess, ReturnTypeWillChange;
+use lang\IllegalAccessException;
+use lang\ast\Node;
+
+/** Comment */
+class Comment extends Node implements ArrayAccess {
+  public $kind= 'comment';
+  public $declaration;
+  public $end= null;
+
+  /**
+   * Creates a new comment
+   *
+   * @param  string $declaration including slashes and asterisks
+   * @param  int $line
+   */
+  public function __construct($declaration= '', $line= -1) {
+    $this->declaration= $declaration;
+    $this->line= $line;
+  }
+
+  /**
+   * Sets comment end line
+   *
+   * @param  int $end
+   * @return self
+   */
+  public function ending($end) {
+    $this->end= $end;
+    return $this;
+  }
+
+  #[ReturnTypeWillChange]
+  public function offsetExists($i) {
+    return $i >= 0 && $i < strlen($this->declaration);
+  }
+
+  #[ReturnTypeWillChange]
+  public function offsetGet($i) {
+    return $this->declaration[$i] ?? null;
+  }
+
+  #[ReturnTypeWillChange]
+  public function offsetSet($i, $value) {
+    throw new IllegalAccessException('Cannot modify comment');
+  }
+
+  #[ReturnTypeWillChange]
+  public function offsetUnset($i) {
+    throw new IllegalAccessException('Cannot modify comment');
+  }
+
+  public function __toString() {
+    return $this->declaration;
+  }
+}

--- a/src/main/php/lang/ast/nodes/Constant.class.php
+++ b/src/main/php/lang/ast/nodes/Constant.class.php
@@ -2,16 +2,17 @@
 
 class Constant extends Annotated implements Member {
   public $kind= 'const';
-  public $name, $modifiers, $expression, $type;
-  public $holder= null;
+  public $name, $modifiers, $expression, $type, $holder;
 
-  public function __construct($modifiers, $name, $type, $expression, $annotations= [], $line= -1) {
+  public function __construct($modifiers, $name, $type, $expression, $annotations= [], $comment= null, $line= -1, $holder= null) {
     $this->modifiers= $modifiers;
     $this->name= $name;
     $this->type= $type;
     $this->expression= $expression;
     $this->annotations= $annotations;
     $this->line= $line;
+    $this->holder= $holder;
+    null === $comment || $this->attach($comment);
   }
 
   /**

--- a/src/main/php/lang/ast/nodes/EnumCase.class.php
+++ b/src/main/php/lang/ast/nodes/EnumCase.class.php
@@ -2,14 +2,15 @@
 
 class EnumCase extends Annotated implements Member {
   public $kind= 'enumcase';
-  public $name, $expression;
-  public $holder= null;
+  public $name, $expression, $holder;
 
-  public function __construct($name, $expression, $annotations, $line= -1) {
+  public function __construct($name, $expression, $annotations, $comment, $line= -1, $holder= null) {
     $this->name= $name;
     $this->expression= $expression;
     $this->annotations= $annotations;
     $this->line= $line;
+    $this->holder= $holder;
+    $comment === null || $this->attach($comment);
   }
 
   /** @return string */

--- a/src/main/php/lang/ast/nodes/Method.class.php
+++ b/src/main/php/lang/ast/nodes/Method.class.php
@@ -2,17 +2,17 @@
 
 class Method extends Annotated implements Member {
   public $kind= 'method';
-  public $name, $modifiers, $signature, $annotations, $body, $comment;
-  public $holder= null;
+  public $name, $modifiers, $signature, $body, $holder;
 
-  public function __construct($modifiers, $name, $signature, $body= null, $annotations= [], $comment= null, $line= -1) {
+  public function __construct($modifiers, $name, $signature, $body= null, $annotations= [], $comment= null, $line= -1, $holder= null) {
     $this->name= $name;
     $this->modifiers= $modifiers;
     $this->signature= $signature;
     $this->body= $body;
     $this->annotations= $annotations;
-    $this->comment= $comment;
     $this->line= $line;
+    $this->holder= $holder;
+    null === $comment || $this->attach($comment);
   }
 
   /**

--- a/src/main/php/lang/ast/nodes/Property.class.php
+++ b/src/main/php/lang/ast/nodes/Property.class.php
@@ -2,17 +2,17 @@
 
 class Property extends Annotated implements Member {
   public $kind= 'property';
-  public $name, $modifiers, $expression, $type, $annotations, $comment;
-  public $holder= null;
+  public $name, $modifiers, $expression, $type, $holder;
 
-  public function __construct($modifiers, $name, $type, $expression= null, $annotations= [], $comment= null, $line= -1) {
+  public function __construct($modifiers, $name, $type, $expression= null, $annotations= [], $comment= null, $line= -1, $holder= null) {
     $this->modifiers= $modifiers;
     $this->name= $name;
     $this->type= $type;
     $this->expression= $expression;
     $this->annotations= $annotations;
-    $this->comment= $comment;
     $this->line= $line;
+    $this->holder= $holder;
+    null === $comment || $this->attach($comment);
   }
 
   /**

--- a/src/main/php/lang/ast/nodes/Signature.class.php
+++ b/src/main/php/lang/ast/nodes/Signature.class.php
@@ -6,9 +6,10 @@ class Signature extends Node {
   public $kind= 'signature';
   public $parameters, $returns;
 
-  public function __construct($parameters= [], $returns= null) {
+  public function __construct($parameters= [], $returns= null, $line= -1) {
     $this->parameters= $parameters;
     $this->returns= $returns;
+    $this->line= $line;
   }
 
   public function add(Parameter $p) {

--- a/src/main/php/lang/ast/nodes/TypeDeclaration.class.php
+++ b/src/main/php/lang/ast/nodes/TypeDeclaration.class.php
@@ -1,19 +1,19 @@
 <?php namespace lang\ast\nodes;
 
 abstract class TypeDeclaration extends Annotated {
-  public $modifiers, $name, $body, $annotations, $comment;
+  public $modifiers, $name, $body;
 
   public function __construct($modifiers, $name, $body= [], $annotations= [], $comment= null, $line= -1) {
     $this->modifiers= $modifiers;
     $this->name= $name;
     $this->annotations= $annotations;
-    $this->comment= $comment;
     $this->line= $line;
     $this->body= [];
     foreach ($body as $lookup => $node) {
       $node->holder= $this->name;
       $this->body[$lookup]= $node;
     }
+    null === $comment || $this->attach($comment);
   }
 
   /** @return iterable */

--- a/src/main/php/lang/ast/syntax/PHP.class.php
+++ b/src/main/php/lang/ast/syntax/PHP.class.php
@@ -1422,6 +1422,7 @@ class PHP extends Language {
   }
 
   public function signature($parse, $annotations= []) {
+    $line= $parse->token->line;
     $parse->expecting('(', 'signature');
     $parameters= $this->parameters($parse, $annotations);
     $parse->expecting(')', 'signature');
@@ -1433,7 +1434,7 @@ class PHP extends Language {
       $return= null;
     }
 
-    return new Signature($parameters, $return);
+    return new Signature($parameters, $return, $line);
   }
 
   public function block($parse) {

--- a/src/main/php/lang/ast/syntax/PHP.class.php
+++ b/src/main/php/lang/ast/syntax/PHP.class.php
@@ -1250,9 +1250,9 @@ class PHP extends Language {
   }
 
   private function properties($parse, &$body, $meta, $modifiers, $type, $holder) {
-    $annotations= $meta[DETAIL_ANNOTATIONS] ?? [];
     $comment= $parse->comment;
     $parse->comment= null;
+    $annotations= $meta[DETAIL_ANNOTATIONS] ?? [];
 
     while (';' !== $parse->token->value) {
       $line= $parse->token->line;

--- a/src/main/php/lang/ast/syntax/PHP.class.php
+++ b/src/main/php/lang/ast/syntax/PHP.class.php
@@ -1251,7 +1251,8 @@ class PHP extends Language {
 
   private function properties($parse, &$body, $meta, $modifiers, $type, $holder) {
     $annotations= $meta[DETAIL_ANNOTATIONS] ?? [];
-    $comment= $meta[DETAIL_COMMENT] ?? null;
+    $comment= $parse->comment;
+    $parse->comment= null;
 
     while (';' !== $parse->token->value) {
       $line= $parse->token->line;
@@ -1400,9 +1401,6 @@ class PHP extends Language {
         $f($parse, $body, $meta, $modifiers, $holder);
         $modifiers= [];
         $meta= [];
-      } else if ('comment' === $parse->token->kind) {
-        $meta[DETAIL_COMMENT]= new Comment($parse->token->value, $parse->token->line);
-        $parse->forward();
       } else if ('#[' === $parse->token->value) {
         $parse->forward();
         $meta[DETAIL_ANNOTATIONS]= $this->attributes($parse, 'member attributes');

--- a/src/main/php/lang/ast/syntax/PHP.class.php
+++ b/src/main/php/lang/ast/syntax/PHP.class.php
@@ -12,6 +12,7 @@ use lang\ast\nodes\{
   CatchStatement,
   ClassDeclaration,
   ClosureExpression,
+  Comment,
   Constant,
   ContinueStatement,
   Directives,
@@ -332,7 +333,7 @@ class PHP extends Language {
           $parse->forward();
 
           if (null === $type) {
-            $class= $this->clazz($parse, null);
+            $class= $this->class($parse, null);
             $class->annotations= $annotations;
             $new= new NewClassExpression($class, null, $token->line);
           } else {
@@ -350,7 +351,7 @@ class PHP extends Language {
       $parse->expecting(')', 'new arguments');
 
       if (null === $type) {
-        $class= $this->clazz($parse, null);
+        $class= $this->class($parse, null);
         $class->annotations= $annotations;
         return new NewClassExpression($class, $arguments, $token->line);
       } else {
@@ -874,17 +875,21 @@ class PHP extends Language {
     });
 
     $this->stmt('class', function($parse, $token) {
-      $type= $parse->scope->resolve($parse->token->value);
+      $comment= $parse->comment;
+      $parse->comment= null;
+
+      $name= $parse->scope->resolve($parse->token->value);
       $parse->forward();
 
-      return $this->clazz($parse, $type);
+      return $this->class($parse, $name, $comment);
     });
 
     $this->stmt('interface', function($parse, $token) {
-      $name= $parse->scope->resolve($parse->token->value);
-      $parse->forward();
       $comment= $parse->comment;
       $parse->comment= null;
+
+      $name= $parse->scope->resolve($parse->token->value);
+      $parse->forward();
 
       $parents= [];
       if ('extends' === $parse->token->value) {
@@ -911,10 +916,11 @@ class PHP extends Language {
     });
 
     $this->stmt('trait', function($parse, $token) {
-      $name= $parse->scope->resolve($parse->token->value);
-      $parse->forward();
       $comment= $parse->comment;
       $parse->comment= null;
+
+      $name= $parse->scope->resolve($parse->token->value);
+      $parse->forward();
 
       $decl= new TraitDeclaration([], $name, [], [], $comment, $token->line);
       $parse->expecting('{', 'trait');
@@ -925,10 +931,11 @@ class PHP extends Language {
     });
 
     $this->stmt('enum', function($parse, $token) {
-      $name= $parse->scope->resolve($parse->token->value);
-      $parse->forward();
       $comment= $parse->comment;
       $parse->comment= null;
+
+      $name= $parse->scope->resolve($parse->token->value);
+      $parse->forward();
 
       $implements= [];
       if ('implements' === $parse->token->value) {
@@ -965,6 +972,9 @@ class PHP extends Language {
     });
 
     $this->body('case', function($parse, &$body, $meta, $modifiers, $holder) {
+      $comment= $parse->comment;
+      $parse->comment= null;
+
       $parse->forward();
       do {
         $line= $parse->token->line;
@@ -978,8 +988,7 @@ class PHP extends Language {
           $expr= null;
         }
 
-        $body[$name]= new EnumCase($name, $expr, $meta[DETAIL_ANNOTATIONS] ?? [], $line);
-        $body[$name]->holder= $holder;
+        $body[$name]= new EnumCase($name, $expr, $meta[DETAIL_ANNOTATIONS] ?? [], $comment, $line, $holder);
       } while (',' === $parse->token->value && true | $parse->forward());
 
       $parse->expecting(';', 'case');
@@ -1028,6 +1037,8 @@ class PHP extends Language {
     });
 
     $this->body('const', function($parse, &$body, $meta, $modifiers, $holder) {
+      $comment= $parse->comment;
+      $parse->comment= null;
       $parse->forward();
 
       $type= null;
@@ -1061,9 +1072,10 @@ class PHP extends Language {
           $type,
           $this->expression($parse, 0),
           $meta[DETAIL_ANNOTATIONS] ?? [],
-          $line
+          $comment,
+          $line,
+          $holder
         );
-        $body[$name]->holder= $holder;
         if (',' === $parse->token->value) {
           $parse->forward();
         }
@@ -1076,9 +1088,9 @@ class PHP extends Language {
     });
 
     $this->body('function', function($parse, &$body, $meta, $modifiers, $holder) {
-      $line= $parse->token->line;
       $comment= $parse->comment;
       $parse->comment= null;
+      $line= $parse->token->line;
 
       $parse->forward();
       $name= $parse->token->value;
@@ -1109,9 +1121,9 @@ class PHP extends Language {
         $statements,
         $meta[DETAIL_ANNOTATIONS] ?? [],
         $comment,
-        $line
+        $line,
+        $holder
       );
-      $body[$lookup]->holder= $holder;
     });
   }
 
@@ -1238,9 +1250,8 @@ class PHP extends Language {
   }
 
   private function properties($parse, &$body, $meta, $modifiers, $type, $holder) {
-    $comment= $parse->comment;
-    $parse->comment= null;
     $annotations= $meta[DETAIL_ANNOTATIONS] ?? [];
+    $comment= $meta[DETAIL_COMMENT] ?? null;
 
     while (';' !== $parse->token->value) {
       $line= $parse->token->line;
@@ -1264,8 +1275,7 @@ class PHP extends Language {
       } else {
         $expr= null;
       }
-      $body[$name]= new Property($modifiers, substr($name, 1), $type, $expr, $annotations, $comment, $line);
-      $body[$name]->holder= $holder;
+      $body[$name]= new Property($modifiers, substr($name, 1), $type, $expr, $annotations, $comment, $line, $holder);
 
       if (',' === $parse->token->value) {
         $parse->forward();
@@ -1390,9 +1400,12 @@ class PHP extends Language {
         $f($parse, $body, $meta, $modifiers, $holder);
         $modifiers= [];
         $meta= [];
+      } else if ('comment' === $parse->token->kind) {
+        $meta[DETAIL_COMMENT]= new Comment($parse->token->value, $parse->token->line);
+        $parse->forward();
       } else if ('#[' === $parse->token->value) {
         $parse->forward();
-        $meta= [DETAIL_ANNOTATIONS => $this->attributes($parse, 'member attributes')];
+        $meta[DETAIL_ANNOTATIONS]= $this->attributes($parse, 'member attributes');
       } else if ($type= $this->type($parse)) {
         $this->properties($parse, $body, $meta, $modifiers, $type, $holder);
         $modifiers= [];
@@ -1434,11 +1447,8 @@ class PHP extends Language {
     }
   }
 
-  public function clazz($parse, $name, $modifiers= []) {
-    $comment= $parse->comment;
-    $parse->comment= null;
+  public function class($parse, $name, $comment= null, $modifiers= []) {
     $line= $parse->token->line;
-
     $parent= null;
     if ('extends' === $parse->token->value) {
       $parse->forward();

--- a/src/test/php/lang/ast/unittest/TokensTest.class.php
+++ b/src/test/php/lang/ast/unittest/TokensTest.class.php
@@ -88,6 +88,6 @@ class TokensTest {
 
   #[Test]
   public function apidoc_comment() {
-    $this->assertTokens([['comment' => '/** Test */']], new Tokens('/** Test */'));
+    $this->assertTokens([['apidoc' => '/** Test */']], new Tokens('/** Test */'));
   }
 }

--- a/src/test/php/lang/ast/unittest/parse/ClosuresTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/ClosuresTest.class.php
@@ -23,7 +23,7 @@ class ClosuresTest extends ParseTest {
   #[Test]
   public function with_body() {
     $this->assertParsed(
-      [new ClosureExpression(new Signature([], null), null, [$this->returns], self::LINE)],
+      [new ClosureExpression(new Signature([], null, self::LINE), null, [$this->returns], self::LINE)],
       'function() { return $a + 1; };'
     );
   }
@@ -32,7 +32,7 @@ class ClosuresTest extends ParseTest {
   public function with_param() {
     $params= [new Parameter('a', null, null, false, false, null, [])];
     $this->assertParsed(
-      [new ClosureExpression(new Signature($params, null), null, [$this->returns], self::LINE)],
+      [new ClosureExpression(new Signature($params, null, self::LINE), null, [$this->returns], self::LINE)],
       'function($a) { return $a + 1; };'
     );
   }
@@ -40,7 +40,7 @@ class ClosuresTest extends ParseTest {
   #[Test]
   public function with_use_by_value() {
     $this->assertParsed(
-      [new ClosureExpression(new Signature([], null), ['$a', '$b'], [$this->returns], self::LINE)],
+      [new ClosureExpression(new Signature([], null, self::LINE), ['$a', '$b'], [$this->returns], self::LINE)],
       'function() use($a, $b) { return $a + 1; };'
     );
   }
@@ -48,7 +48,7 @@ class ClosuresTest extends ParseTest {
   #[Test]
   public function with_use_by_reference() {
     $this->assertParsed(
-      [new ClosureExpression(new Signature([], null), ['$a', '&$b'], [$this->returns], self::LINE)],
+      [new ClosureExpression(new Signature([], null, self::LINE), ['$a', '&$b'], [$this->returns], self::LINE)],
       'function() use($a, &$b) { return $a + 1; };'
     );
   }
@@ -56,7 +56,7 @@ class ClosuresTest extends ParseTest {
   #[Test]
   public function with_return_type() {
     $this->assertParsed(
-      [new ClosureExpression(new Signature([], new Type('int')), null, [$this->returns], self::LINE)],
+      [new ClosureExpression(new Signature([], new Type('int'), self::LINE), null, [$this->returns], self::LINE)],
       'function(): int { return $a + 1; };'
     );
   }
@@ -64,7 +64,7 @@ class ClosuresTest extends ParseTest {
   #[Test]
   public function with_nullable_return_type() {
     $this->assertParsed(
-      [new ClosureExpression(new Signature([], new Type('?int')), null, [$this->returns], self::LINE)],
+      [new ClosureExpression(new Signature([], new Type('?int'), self::LINE), null, [$this->returns], self::LINE)],
       'function(): ?int { return $a + 1; };'
     );
   }

--- a/src/test/php/lang/ast/unittest/parse/CommentTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/CommentTest.class.php
@@ -1,6 +1,6 @@
 <?php namespace lang\ast\unittest\parse;
 
-use lang\ast\nodes\{ClassDeclaration, Literal};
+use lang\ast\nodes\{ClassDeclaration, Comment, Method, Signature, Literal};
 use unittest\{Assert, Test};
 
 class CommentTest extends ParseTest {
@@ -86,10 +86,46 @@ class CommentTest extends ParseTest {
   }
 
   #[Test]
+  public function apidoc_comment_at_end_discarded() {
+    $this->assertParsed([new Literal('"test"', 2)], '
+      "test";  /** Discarded */
+    ');
+  }
+
+  #[Test]
+  public function apidoc_comment_after_class_name_discarded() {
+    $this->assertParsed([new ClassDeclaration([], '\\T', null, [], [], [], null, 2)], '
+      class T /** Discarded */ { }
+    ');
+  }
+
+  #[Test]
   public function apidoc_comment_attached_to_next_node() {
-    $this->assertParsed([new ClassDeclaration([], '\\T', null, [], [], [], '/** @see http://example.org/ */', 3)], '
-      /** @see http://example.org/ */
+    $this->assertParsed([new ClassDeclaration([], '\\T', null, [], [], [], new Comment('/** @api */', 2), 3)], '
+      /** @api */
       class T { }
+    ');
+  }
+
+  #[Test]
+  public function apidoc_comment_and_annotations() {
+    $this->assertParsed([new ClassDeclaration([], '\\T', null, [], [], ['Test' => []], new Comment('/** @api */', 2), 4)], '
+      /** @api */
+      #[Test]
+      class T { }
+    ');
+  }
+
+  #[Test]
+  public function apidoc_comment_attached_to_next_member() {
+    $class= new ClassDeclaration([], '\\T', null, [], [], [], null, 2);
+    $class->declare(new Method(['public'], '__construct', new Signature([], null), [], [], new Comment('/** @api */', 3), 4));
+
+    $this->assertParsed([$class], '
+      class T {
+        /** @api */
+        public function __construct() { }
+      }
     ');
   }
 }

--- a/src/test/php/lang/ast/unittest/parse/CommentTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/CommentTest.class.php
@@ -119,7 +119,7 @@ class CommentTest extends ParseTest {
   #[Test]
   public function apidoc_comment_attached_to_next_member() {
     $class= new ClassDeclaration([], '\\T', null, [], [], [], null, 2);
-    $class->declare(new Method(['public'], '__construct', new Signature([], null), [], [], new Comment('/** @api */', 3), 4));
+    $class->declare(new Method(['public'], '__construct', new Signature([], null, 4), [], [], new Comment('/** @api */', 3), 4));
 
     $this->assertParsed([$class], '
       class T {

--- a/src/test/php/lang/ast/unittest/parse/CommentTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/CommentTest.class.php
@@ -1,6 +1,6 @@
 <?php namespace lang\ast\unittest\parse;
 
-use lang\ast\nodes\{ClassDeclaration, Comment, Method, Signature, Literal};
+use lang\ast\nodes\{ClassDeclaration, Comment, Constant, Property, Method, Signature, Literal};
 use unittest\{Assert, Test};
 
 class CommentTest extends ParseTest {
@@ -117,9 +117,35 @@ class CommentTest extends ParseTest {
   }
 
   #[Test]
-  public function apidoc_comment_attached_to_next_member() {
+  public function apidoc_comment_attached_to_next_constant() {
     $class= new ClassDeclaration([], '\\T', null, [], [], [], null, 2);
-    $class->declare(new Method(['public'], '__construct', new Signature([], null, 4), [], [], new Comment('/** @api */', 3), 4));
+    $class->declare(new Constant(['public'], 'FIXTURE', null, new Literal('1', 4), [], new Comment('/** @api */', 3), 4));
+
+    $this->assertParsed([$class], '
+      class T {
+        /** @api */
+        public const FIXTURE = 1;
+      }
+    ');
+  }
+
+  #[Test]
+  public function apidoc_comment_attached_to_next_property() {
+    $class= new ClassDeclaration([], '\\T', null, [], [], [], null, 2);
+    $class->declare(new Property(['public'], 'fixture', null, null, [], new Comment('/** @api */', 3), 4));
+
+    $this->assertParsed([$class], '
+      class T {
+        /** @api */
+        public $fixture;
+      }
+    ');
+  }
+
+  #[Test]
+  public function apidoc_comment_attached_to_next_method() {
+    $class= new ClassDeclaration([], '\\T', null, [], [], [], null, 2);
+    $class->declare(new Method(['public'], '__construct', new Signature([], null, 4), [], [], new Comment('/** @api */', 3), 3));
 
     $this->assertParsed([$class], '
       class T {

--- a/src/test/php/lang/ast/unittest/parse/FunctionsTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/FunctionsTest.class.php
@@ -36,7 +36,7 @@ class FunctionsTest extends ParseTest {
   #[Test]
   public function empty_function_without_parameters() {
     $this->assertParsed(
-      [new FunctionDeclaration('a', new Signature([], null), [], self::LINE)],
+      [new FunctionDeclaration('a', new Signature([], null, self::LINE), [], self::LINE)],
       'function a() { }'
     );
   }
@@ -45,8 +45,8 @@ class FunctionsTest extends ParseTest {
   public function two_functions() {
     $this->assertParsed(
       [
-        new FunctionDeclaration('a', new Signature([], null), [], self::LINE),
-        new FunctionDeclaration('b', new Signature([], null), [], self::LINE)
+        new FunctionDeclaration('a', new Signature([], null, self::LINE), [], self::LINE),
+        new FunctionDeclaration('b', new Signature([], null, self::LINE), [], self::LINE)
       ],
       'function a() { } function b() { }'
     );
@@ -56,7 +56,7 @@ class FunctionsTest extends ParseTest {
   public function with_parameter($name) {
     $params= [new Parameter($name, null, null, false, false, null, [])];
     $this->assertParsed(
-      [new FunctionDeclaration('a', new Signature($params, null), [], self::LINE)],
+      [new FunctionDeclaration('a', new Signature($params, null, self::LINE), [], self::LINE)],
       'function a($'.$name.') { }'
     );
   }
@@ -65,7 +65,7 @@ class FunctionsTest extends ParseTest {
   public function with_reference_parameter() {
     $params= [new Parameter('param', null, null, true, false, null, [])];
     $this->assertParsed(
-      [new FunctionDeclaration('a', new Signature($params, null), [], self::LINE)],
+      [new FunctionDeclaration('a', new Signature($params, null, self::LINE), [], self::LINE)],
       'function a(&$param) { }'
     );
   }
@@ -74,7 +74,7 @@ class FunctionsTest extends ParseTest {
   public function dangling_comma_in_parameter_lists() {
     $params= [new Parameter('param', null, null, false, false, null, [])];
     $this->assertParsed(
-      [new FunctionDeclaration('a', new Signature($params, null), [], self::LINE)],
+      [new FunctionDeclaration('a', new Signature($params, null, self::LINE), [], self::LINE)],
       'function a($param, ) { }'
     );
   }
@@ -83,7 +83,7 @@ class FunctionsTest extends ParseTest {
   public function with_typed_parameter($declaration, $expected) {
     $params= [new Parameter('param', $expected, null, false, false, null, [])];
     $this->assertParsed(
-      [new FunctionDeclaration('a', new Signature($params, null), [], self::LINE)],
+      [new FunctionDeclaration('a', new Signature($params, null, self::LINE), [], self::LINE)],
       'function a('.$declaration.' $param) { }'
     );
   }
@@ -92,7 +92,7 @@ class FunctionsTest extends ParseTest {
   public function with_nullable_typed_parameter() {
     $params= [new Parameter('param', new IsNullable(new IsLiteral('string')), null, false, false, null, [])];
     $this->assertParsed(
-      [new FunctionDeclaration('a', new Signature($params, null), [], self::LINE)],
+      [new FunctionDeclaration('a', new Signature($params, null, self::LINE), [], self::LINE)],
       'function a(?string $param) { }'
     );
   }
@@ -101,7 +101,7 @@ class FunctionsTest extends ParseTest {
   public function with_variadic_parameter() {
     $params= [new Parameter('param', null, null, false, true, null, [])];
     $this->assertParsed(
-      [new FunctionDeclaration('a', new Signature($params, null), [], self::LINE)],
+      [new FunctionDeclaration('a', new Signature($params, null, self::LINE), [], self::LINE)],
       'function a(... $param) { }'
     );
   }
@@ -110,7 +110,7 @@ class FunctionsTest extends ParseTest {
   public function with_optional_parameter() {
     $params= [new Parameter('param', null, new Literal('null', self::LINE), false, false, null, [])];
     $this->assertParsed(
-      [new FunctionDeclaration('a', new Signature($params, null), [], self::LINE)],
+      [new FunctionDeclaration('a', new Signature($params, null, self::LINE), [], self::LINE)],
       'function a($param= null) { }'
     );
   }
@@ -119,7 +119,7 @@ class FunctionsTest extends ParseTest {
   public function with_parameter_named_function() {
     $params= [new Parameter('function', null, null, false, false, null, [])];
     $this->assertParsed(
-      [new FunctionDeclaration('a', new Signature($params, null), [], self::LINE)],
+      [new FunctionDeclaration('a', new Signature($params, null, self::LINE), [], self::LINE)],
       'function a($function, ) { }'
     );
   }
@@ -128,7 +128,7 @@ class FunctionsTest extends ParseTest {
   public function with_typed_parameter_named_function() {
     $params= [new Parameter('function', new IsFunction([], new IsLiteral('void')), null, false, false, null, [])];
     $this->assertParsed(
-      [new FunctionDeclaration('a', new Signature($params, null), [], self::LINE)],
+      [new FunctionDeclaration('a', new Signature($params, null, self::LINE), [], self::LINE)],
       'function a((function(): void) $function) { }'
     );
   }
@@ -136,7 +136,7 @@ class FunctionsTest extends ParseTest {
   #[Test, Values('types')]
   public function with_return_type($declaration, $expected) {
     $this->assertParsed(
-      [new FunctionDeclaration('a', new Signature([], $expected), [], self::LINE)],
+      [new FunctionDeclaration('a', new Signature([], $expected, self::LINE), [], self::LINE)],
       'function a(): '.$declaration.' { }'
     );
   }
@@ -145,7 +145,7 @@ class FunctionsTest extends ParseTest {
   public function generator() {
     $yield= new YieldExpression(null, null, self::LINE);
     $this->assertParsed(
-      [new FunctionDeclaration('a', new Signature([], null), [$yield], self::LINE)],
+      [new FunctionDeclaration('a', new Signature([], null, self::LINE), [$yield], self::LINE)],
       'function a() { yield; }'
     );
   }
@@ -154,7 +154,7 @@ class FunctionsTest extends ParseTest {
   public function generator_with_value() {
     $yield= new YieldExpression(null, new Literal('1', self::LINE), self::LINE);
     $this->assertParsed(
-      [new FunctionDeclaration('a', new Signature([], null), [$yield], self::LINE)],
+      [new FunctionDeclaration('a', new Signature([], null, self::LINE), [$yield], self::LINE)],
       'function a() { yield 1; }'
     );
   }
@@ -163,7 +163,7 @@ class FunctionsTest extends ParseTest {
   public function generator_with_key_and_value() {
     $yield= new YieldExpression(new Literal('"number"', self::LINE), new Literal('1', self::LINE), self::LINE);
     $this->assertParsed(
-      [new FunctionDeclaration('a', new Signature([], null), [$yield], self::LINE)],
+      [new FunctionDeclaration('a', new Signature([], null, self::LINE), [$yield], self::LINE)],
       'function a() { yield "number" => 1; }'
     );
   }
@@ -172,7 +172,7 @@ class FunctionsTest extends ParseTest {
   public function generator_delegation() {
     $yield= new YieldFromExpression(new ArrayLiteral([], self::LINE), self::LINE);
     $this->assertParsed(
-      [new FunctionDeclaration('a', new Signature([], null), [$yield], self::LINE)],
+      [new FunctionDeclaration('a', new Signature([], null, self::LINE), [$yield], self::LINE)],
       'function a() { yield from []; }'
     );
   }
@@ -186,7 +186,7 @@ class FunctionsTest extends ParseTest {
       self::LINE
     );
     $this->assertParsed(
-      [new FunctionDeclaration('a', new Signature([], null), [$yield], self::LINE)],
+      [new FunctionDeclaration('a', new Signature([], null, self::LINE), [$yield], self::LINE)],
       'function a() { $value= yield; }'
     );
   }
@@ -200,7 +200,7 @@ class FunctionsTest extends ParseTest {
       self::LINE
     );
     $this->assertParsed(
-      [new FunctionDeclaration('a', new Signature([], null), [$yield], self::LINE)],
+      [new FunctionDeclaration('a', new Signature([], null, self::LINE), [$yield], self::LINE)],
       'function a() { $value= yield (1); }'
     );
   }
@@ -215,7 +215,7 @@ class FunctionsTest extends ParseTest {
       self::LINE
     );
     $this->assertParsed(
-      [new FunctionDeclaration('a', new Signature([], null), [$yield], self::LINE)],
+      [new FunctionDeclaration('a', new Signature([], null, self::LINE), [$yield], self::LINE)],
       'function a() { $value= (yield); }'
     );
   }
@@ -229,7 +229,7 @@ class FunctionsTest extends ParseTest {
       self::LINE
     );
     $this->assertParsed(
-      [new FunctionDeclaration('a', new Signature([], null), [$yield], self::LINE)],
+      [new FunctionDeclaration('a', new Signature([], null, self::LINE), [$yield], self::LINE)],
       $declaration
     );
   }
@@ -243,7 +243,7 @@ class FunctionsTest extends ParseTest {
       self::LINE
     );
     $this->assertParsed(
-      [new FunctionDeclaration('a', new Signature([], null), [$yield], self::LINE)],
+      [new FunctionDeclaration('a', new Signature([], null, self::LINE), [$yield], self::LINE)],
       $declaration
     );
   }

--- a/src/test/php/lang/ast/unittest/parse/LambdasTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/LambdasTest.class.php
@@ -14,7 +14,7 @@ class LambdasTest extends ParseTest {
   #[Test]
   public function short_closure() {
     $this->assertParsed(
-      [new LambdaExpression(new Signature([new Parameter('a', null)], null), $this->expression, self::LINE)],
+      [new LambdaExpression(new Signature([new Parameter('a', null)], null, self::LINE), $this->expression, self::LINE)],
       'fn($a) => $a + 1;'
     );
   }
@@ -24,7 +24,7 @@ class LambdasTest extends ParseTest {
     $this->assertParsed(
       [new InvokeExpression(
         new Literal('execute', self::LINE),
-        [new LambdaExpression(new Signature([new Parameter('a', null)], null), $this->expression, self::LINE)],
+        [new LambdaExpression(new Signature([new Parameter('a', null)], null, self::LINE), $this->expression, self::LINE)],
         self::LINE
       )],
       'execute(fn($a) => $a + 1);'
@@ -35,7 +35,7 @@ class LambdasTest extends ParseTest {
   public function short_closure_with_block() {
     $this->assertParsed(
       [new LambdaExpression(
-        new Signature([new Parameter('a', null)], null),
+        new Signature([new Parameter('a', null)], null, self::LINE),
         new Block([new ReturnStatement($this->expression, self::LINE)], self::LINE),
         self::LINE
       )],

--- a/src/test/php/lang/ast/unittest/parse/MembersTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/MembersTest.class.php
@@ -41,7 +41,7 @@ class MembersTest extends ParseTest {
   #[Test]
   public function private_instance_method() {
     $class= new ClassDeclaration([], '\\A', null, [], [], [], null, self::LINE);
-    $class->declare(new Method(['private'], 'a', new Signature([], null), [], [], null, self::LINE));
+    $class->declare(new Method(['private'], 'a', new Signature([], null, self::LINE), [], [], null, self::LINE));
 
     $this->assertParsed([$class], 'class A { private function a() { } }');
   }
@@ -49,7 +49,7 @@ class MembersTest extends ParseTest {
   #[Test]
   public function private_static_method() {
     $class= new ClassDeclaration([], '\\A', null, [], [], [], null, self::LINE);
-    $class->declare(new Method(['private', 'static'], 'a', new Signature([], null), [], [], null, self::LINE));
+    $class->declare(new Method(['private', 'static'], 'a', new Signature([], null, self::LINE), [], [], null, self::LINE));
 
     $this->assertParsed([$class], 'class A { private static function a() { } }');
   }
@@ -83,7 +83,7 @@ class MembersTest extends ParseTest {
   public function method_with_typed_parameter($declaration, $expected) {
     $class= new ClassDeclaration([], '\\A', null, [], [], [], null, self::LINE);
     $params= [new Parameter('param', $expected, null, false, false, null, [])];
-    $class->declare(new Method(['public'], 'a', new Signature($params, null), [], [], null, self::LINE));
+    $class->declare(new Method(['public'], 'a', new Signature($params, null, self::LINE), [], [], null, self::LINE));
 
     $this->assertParsed([$class], 'class A { public function a('.$declaration.' $param) { } }');
   }
@@ -91,7 +91,7 @@ class MembersTest extends ParseTest {
   #[Test, Values('types')]
   public function method_with_return_type($declaration, $expected) {
     $class= new ClassDeclaration([], '\\A', null, [], [], [], null, self::LINE);
-    $class->declare(new Method(['public'], 'a', new Signature([], $expected), [], [], null, self::LINE));
+    $class->declare(new Method(['public'], 'a', new Signature([], $expected, self::LINE), [], [], null, self::LINE));
 
     $this->assertParsed([$class], 'class A { public function a(): '.$declaration.' { } }');
   }
@@ -100,7 +100,7 @@ class MembersTest extends ParseTest {
   public function method_with_annotation() {
     $annotations= ['Test' => []];
     $class= new ClassDeclaration([], '\\A', null, [], [], [], null, self::LINE);
-    $class->declare(new Method(['public'], 'a', new Signature([], null), [], $annotations, null, self::LINE));
+    $class->declare(new Method(['public'], 'a', new Signature([], null, self::LINE), [], $annotations, null, self::LINE));
 
     $this->assertParsed([$class], 'class A { #[Test] public function a() { } }');
   }
@@ -109,7 +109,7 @@ class MembersTest extends ParseTest {
   public function method_with_annotations() {
     $annotations= ['Test' => [], 'Ignore' => [new Literal('"Not implemented"', self::LINE)]];
     $class= new ClassDeclaration([], '\\A', null, [], [], [], null, self::LINE);
-    $class->declare(new Method(['public'], 'a', new Signature([], null), [], $annotations, null, self::LINE));
+    $class->declare(new Method(['public'], 'a', new Signature([], null, self::LINE), [], $annotations, null, self::LINE));
 
     $this->assertParsed([$class], 'class A { #[Test, Ignore("Not implemented")] public function a() { } }');
   }

--- a/src/test/php/lang/ast/unittest/parse/MembersTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/MembersTest.class.php
@@ -57,7 +57,7 @@ class MembersTest extends ParseTest {
   #[Test]
   public function class_constant() {
     $class= new ClassDeclaration([], '\\A', null, [], [], [], null, self::LINE);
-    $class->declare(new Constant([], 'T', null, new Literal('1', self::LINE), [], self::LINE));
+    $class->declare(new Constant([], 'T', null, new Literal('1', self::LINE), [], null, self::LINE));
 
     $this->assertParsed([$class], 'class A { const T = 1; }');
   }
@@ -65,8 +65,8 @@ class MembersTest extends ParseTest {
   #[Test]
   public function class_constants() {
     $class= new ClassDeclaration([], '\\A', null, [], [], [], null, self::LINE);
-    $class->declare(new Constant([], 'T', null, new Literal('1', self::LINE), [], self::LINE));
-    $class->declare(new Constant([], 'S', null, new Literal('2', self::LINE), [], self::LINE));
+    $class->declare(new Constant([], 'T', null, new Literal('1', self::LINE), [], null, self::LINE));
+    $class->declare(new Constant([], 'S', null, new Literal('2', self::LINE), [], null, self::LINE));
 
     $this->assertParsed([$class], 'class A { const T = 1, S = 2; }');
   }
@@ -74,7 +74,7 @@ class MembersTest extends ParseTest {
   #[Test]
   public function private_class_constant() {
     $class= new ClassDeclaration([], '\\A', null, [], [], [], null, self::LINE);
-    $class->declare(new Constant(['private'], 'T', null, new Literal('1', self::LINE), [], self::LINE));
+    $class->declare(new Constant(['private'], 'T', null, new Literal('1', self::LINE), [], null, self::LINE));
 
     $this->assertParsed([$class], 'class A { private const T = 1; }');
   }
@@ -236,7 +236,7 @@ class MembersTest extends ParseTest {
   #[Test]
   public function typed_constant() {
     $class= new ClassDeclaration([], '\\A', null, [], [], [], null, self::LINE);
-    $class->declare(new Constant([], 'T', new Type('int'), new Literal('1', self::LINE), [], self::LINE));
+    $class->declare(new Constant([], 'T', new Type('int'), new Literal('1', self::LINE), [], null, self::LINE));
 
     $this->assertParsed([$class], 'class A { const int T = 1; }');
   }
@@ -244,9 +244,9 @@ class MembersTest extends ParseTest {
   #[Test]
   public function typed_constants() {
     $class= new ClassDeclaration([], '\\A', null, [], [], [], null, self::LINE);
-    $class->declare(new Constant([], 'T', new Type('int'), new Literal('1', self::LINE), [], self::LINE));
-    $class->declare(new Constant([], 'S', new Type('int'), new Literal('2', self::LINE), [], self::LINE));
-    $class->declare(new Constant([], 'I', new Type('string'), new Literal('"i"', self::LINE), [], self::LINE));
+    $class->declare(new Constant([], 'T', new Type('int'), new Literal('1', self::LINE), [], null, self::LINE));
+    $class->declare(new Constant([], 'S', new Type('int'), new Literal('2', self::LINE), [], null, self::LINE));
+    $class->declare(new Constant([], 'I', new Type('string'), new Literal('"i"', self::LINE), [], null, self::LINE));
 
     $this->assertParsed([$class], 'class A { const int T = 1, S = 2, string I = "i"; }');
   }

--- a/src/test/php/lang/ast/unittest/parse/TypesTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/TypesTest.class.php
@@ -114,24 +114,24 @@ class TypesTest extends ParseTest {
   #[Test]
   public function unit_enum_with_cases() {
     $enum= new EnumDeclaration([], '\\A', null, [], [], [], null, self::LINE);
-    $enum->declare(new EnumCase('ONE', null, [], self::LINE));
-    $enum->declare(new EnumCase('TWO', null, [], self::LINE));
+    $enum->declare(new EnumCase('ONE', null, [], null, self::LINE));
+    $enum->declare(new EnumCase('TWO', null, [], null, self::LINE));
     $this->assertParsed([$enum], 'enum A { case ONE; case TWO; }');
   }
 
   #[Test]
   public function backed_enum_with_cases() {
     $enum= new EnumDeclaration([], '\\A', 'int', [], [], [], null, self::LINE);
-    $enum->declare(new EnumCase('ONE', new Literal('1', self::LINE), [], self::LINE));
-    $enum->declare(new EnumCase('TWO', new Literal('2', self::LINE), [], self::LINE));
+    $enum->declare(new EnumCase('ONE', new Literal('1', self::LINE), [], null, self::LINE));
+    $enum->declare(new EnumCase('TWO', new Literal('2', self::LINE), [], null, self::LINE));
     $this->assertParsed([$enum], 'enum A: int { case ONE = 1; case TWO = 2; }');
   }
 
   #[Test]
   public function unit_enum_with_grouped_cases() {
     $enum= new EnumDeclaration([], '\\A', null, [], [], [], null, self::LINE);
-    $enum->declare(new EnumCase('ONE', null, [], self::LINE));
-    $enum->declare(new EnumCase('TWO', null, [], self::LINE));
+    $enum->declare(new EnumCase('ONE', null, [], null, self::LINE));
+    $enum->declare(new EnumCase('TWO', null, [], null, self::LINE));
     $this->assertParsed([$enum], 'enum A { case ONE, TWO; }');
   }
 


### PR DESCRIPTION
This pull request changes the *$comment* member from holding strings to instances of the new `lang.ast.nodes.Comment` class. It also adds a bit of consistency:

* Elements with apidoc comments attached will start at the line the comment starts
* EnumCase and Constant nodes now also have apidoc comments attached
* Comment member has moved to the Annotated parent class 

⚠️ This pull request breaks BC and requires changes to the compiler:

```diff
diff --git a/src/main/php/lang/ast/emit/PHP.class.php b/src/main/php/lang/ast/emit/PHP.class.php
index 661fbff..3ec5122 100755
--- a/src/main/php/lang/ast/emit/PHP.class.php
+++ b/src/main/php/lang/ast/emit/PHP.class.php
@@ -453,15 +453,9 @@ abstract class PHP extends Emitter {
     $result->out->write(']');
   }
 
-  /** Removes leading, intermediate and trailing stars from apidoc comments */
+  /** Emit comment inside meta information */
   private function comment($comment) {
-    if (null === $comment || '' === $comment) {
-      return 'null';
-    } else if ('/' === $comment[0]) {
-      return "'".str_replace("'", "\\'", trim(preg_replace('/\n\s+\* ?/', "\n", substr($comment, 3, -2))))."'";
-    } else {
-      return "'".str_replace("'", "\\'", $comment)."'";
-    }
+    return null === $comment ? 'null' : var_export($comment->content(), true);
   }
 
   /** Emit meta information so that the reflection API won't have to parse it */
```