### PR TITLE
Refactor annotations from associative arrays to Annotations instances

### DIFF
--- a/src/main/php/lang/ast/nodes/Annotated.class.php
+++ b/src/main/php/lang/ast/nodes/Annotated.class.php
@@ -30,13 +30,10 @@ abstract class Annotated extends Node {
    * exists by that name.
    *
    * @param  string $name
-   * @return lang.ast.nodes.Annotation
+   * @return ?lang.ast.nodes.Annotation
    */
   public function annotation($name) {
-    return array_key_exists($name, $this->annotations)
-      ? new Annotation($name, $this->annotations[$name])
-      : null
-    ;
+    return $this->annotations ? $this->annotations->named($name) : null;
   }
 
   /**

--- a/src/main/php/lang/ast/nodes/Annotated.class.php
+++ b/src/main/php/lang/ast/nodes/Annotated.class.php
@@ -46,6 +46,19 @@ abstract class Annotated extends Node {
   }
 
   /**
+   * Annotate this element with a given annotation
+   *
+   * @param  lang.ast.nodes.Annotation $annotation
+   * @return self
+   */
+  public function annotate($annotation) {
+    if (null === $this->annotations) $this->annotations= new Annotations([], $this->line);
+
+    $this->annotations->add($annotation);
+    return $this;
+  }
+
+  /**
    * Checks whether this node is of a given kind
    *
    * @param  string $kind

--- a/src/main/php/lang/ast/nodes/Annotated.class.php
+++ b/src/main/php/lang/ast/nodes/Annotated.class.php
@@ -26,6 +26,15 @@ abstract class Annotated extends Node {
   }
 
   /**
+   * Returns all annotations on this element
+   *
+   * @return [:lang.ast.nodes.Annotation]
+   */
+  public function annotations() {
+    return $this->annotations ? $this->annotations->all() : [];
+  }
+
+  /**
    * Returns an annotation for a given name, or NULL if no annotation
    * exists by that name.
    *

--- a/src/main/php/lang/ast/nodes/Annotation.class.php
+++ b/src/main/php/lang/ast/nodes/Annotation.class.php
@@ -1,10 +1,17 @@
 <?php namespace lang\ast\nodes;
 
-class Annotation {
-  public $name, $node;
+use lang\ast\Node;
 
-  public function __construct($name, $node) {
+class Annotation extends Node {
+  public $name, $arguments;
+  public $kind= 'annotation';
+
+  public function __construct($name, $arguments, $line= -1) {
     $this->name= $name;
-    $this->node= $node;
+    $this->arguments= $arguments;
+    $this->line= $line;
   }
+
+  /** @return iterable */
+  public function children() { return $this->arguments; }
 }

--- a/src/main/php/lang/ast/nodes/Annotations.class.php
+++ b/src/main/php/lang/ast/nodes/Annotations.class.php
@@ -10,11 +10,13 @@ class Annotations extends Node implements IteratorAggregate {
   /**
    * Creates annotations
    *
-   * @param  [:lang.ast.nodes.Annotation|var[]] $named
+   * @param  lang.ast.nodes.Annotation|[:lang.ast.nodes.Annotation|var[]] $arg
    * @param  int $line
    */
-  public function __construct($named= [], $line= -1) {
-    foreach ($named as $name => $value) {
+  public function __construct($arg= [], $line= -1) {
+    if ($arg instanceof Annotation) {
+      $this->named[$arg->name]= $arg;
+    } else foreach ($arg as $name => $value) {
       $this->named[$name]= $value instanceof Annotation ? $value : new Annotation($name, $value, $line);
     }
     $this->line= $line;

--- a/src/main/php/lang/ast/nodes/Annotations.class.php
+++ b/src/main/php/lang/ast/nodes/Annotations.class.php
@@ -1,0 +1,76 @@
+<?php namespace lang\ast\nodes;
+
+use IteratorAggregate, Traversable;
+use lang\ast\Node;
+
+class Annotations extends Node implements IteratorAggregate {
+  public $named= [];
+  public $kind= 'annotations';
+
+  /**
+   * Creates annotations
+   *
+   * @param  [:lang.ast.nodes.Annotation|var[]] $named
+   * @param  int $line
+   */
+  public function __construct($named= [], $line= -1) {
+    foreach ($named as $name => $value) {
+      $this->named[$name]= $value instanceof Annotation ? $value : new Annotation($name, $value, $line);
+    }
+    $this->line= $line;
+  }
+
+  /** Adds a given annotation */
+  public function add(Annotation $annotation): self {
+    $this->named[$annotation->name]= $annotation;
+    return $this;
+  }
+
+  /**
+   * Remove an annotation and return it, if any.
+   *
+   * @param  string|lang.ast.nodes.Annotation $target
+   * @return ?lang.ast.nodes.Annotation
+   */
+  public function remove($target) {
+    $name= $target instanceof Annotation ? $target->name : $target;
+    if ($removed= $this->named[$name] ?? null) {
+      unset($this->named[$name]);
+      return $removed;
+    }
+    return null;
+  }
+
+  /**
+   * Returns an annotation by its name
+   *
+   * @param  string $name
+   * @return ?lang.ast.nodes.Annotation
+   */
+  public function named($name) {
+    return $this->named[$name] ?? null;
+  }
+
+  /**
+   * Returns all annotations by their name
+   *
+   * @return [:lang.ast.nodes.Annotation]
+   */
+  public function all() {
+    return $this->named;
+  }
+
+  /** Iterates annotation arguments mapped by their names */
+  public function getIterator(): Traversable {
+    foreach ($this->named as $name => $annotation) {
+      yield $name => $annotation->arguments;
+    }
+  }
+
+  /** @return iterable */
+  public function children() {
+    foreach ($this->named as $annotation) {
+      yield $annotation;
+    }
+  }
+}

--- a/src/main/php/lang/ast/nodes/ClassDeclaration.class.php
+++ b/src/main/php/lang/ast/nodes/ClassDeclaration.class.php
@@ -4,7 +4,16 @@ class ClassDeclaration extends TypeDeclaration {
   public $kind= 'class';
   public $parent, $implements;
 
-  public function __construct($modifiers, $name, $parent= null, $implements= [], $body= [], $annotations= [], $comment= null, $line= -1) {
+  public function __construct(
+    $modifiers,
+    $name,
+    $parent= null,
+    $implements= [],
+    $body= [],
+    $annotations= null,
+    $comment= null,
+    $line= -1
+  ) {
     parent::__construct($modifiers, $name, $body, $annotations, $comment, $line);
     $this->parent= $parent;
     $this->implements= $implements;

--- a/src/main/php/lang/ast/nodes/Constant.class.php
+++ b/src/main/php/lang/ast/nodes/Constant.class.php
@@ -9,9 +9,9 @@ class Constant extends Annotated implements Member {
     $this->name= $name;
     $this->type= $type;
     $this->expression= $expression;
-    $this->annotations= $annotations;
-    $this->line= $line;
+    $this->declared= $this->line= $line;
     $this->holder= $holder;
+    null === $annotations || $this->annotate($annotations);
     null === $comment || $this->attach($comment);
   }
 

--- a/src/main/php/lang/ast/nodes/Constant.class.php
+++ b/src/main/php/lang/ast/nodes/Constant.class.php
@@ -4,7 +4,7 @@ class Constant extends Annotated implements Member {
   public $kind= 'const';
   public $name, $modifiers, $expression, $type, $holder;
 
-  public function __construct($modifiers, $name, $type, $expression, $annotations= [], $comment= null, $line= -1, $holder= null) {
+  public function __construct($modifiers, $name, $type, $expression, $annotations= null, $comment= null, $line= -1, $holder= null) {
     $this->modifiers= $modifiers;
     $this->name= $name;
     $this->type= $type;

--- a/src/main/php/lang/ast/nodes/EnumCase.class.php
+++ b/src/main/php/lang/ast/nodes/EnumCase.class.php
@@ -7,10 +7,10 @@ class EnumCase extends Annotated implements Member {
   public function __construct($name, $expression, $annotations, $comment, $line= -1, $holder= null) {
     $this->name= $name;
     $this->expression= $expression;
-    $this->annotations= $annotations;
-    $this->line= $line;
+    $this->declared= $this->line= $line;
     $this->holder= $holder;
-    $comment === null || $this->attach($comment);
+    null === $annotations || $this->annotate($annotations);
+    null === $comment || $this->attach($comment);
   }
 
   /** @return string */

--- a/src/main/php/lang/ast/nodes/EnumDeclaration.class.php
+++ b/src/main/php/lang/ast/nodes/EnumDeclaration.class.php
@@ -6,7 +6,16 @@ class EnumDeclaration extends TypeDeclaration {
   public $kind= 'enum';
   public $base, $implements;
 
-  public function __construct($modifiers, $name, $base, $implements= [], $body= [], $annotations= [], $comment= null, $line= -1) {
+  public function __construct(
+    $modifiers,
+    $name,
+    $base,
+    $implements= [],
+    $body= [],
+    $annotations= null,
+    $comment= null,
+    $line= -1
+  ) {
     parent::__construct($modifiers, $name, $body, $annotations, $comment, $line);
     $this->implements= $implements;
     $this->base= $base;

--- a/src/main/php/lang/ast/nodes/InterfaceDeclaration.class.php
+++ b/src/main/php/lang/ast/nodes/InterfaceDeclaration.class.php
@@ -4,7 +4,15 @@ class InterfaceDeclaration extends TypeDeclaration {
   public $kind= 'interface';
   public $parents;
 
-  public function __construct($modifiers, $name, $parents, $body= [], $annotations= [], $comment= null, $line= -1) {
+  public function __construct(
+    $modifiers,
+    $name,
+    $parents,
+    $body= [],
+    $annotations= null,
+    $comment= null,
+    $line= -1
+  ) {
     parent::__construct($modifiers, $name, $body, $annotations, $comment, $line);
     $this->parents= $parents;
   }

--- a/src/main/php/lang/ast/nodes/Method.class.php
+++ b/src/main/php/lang/ast/nodes/Method.class.php
@@ -4,7 +4,7 @@ class Method extends Annotated implements Member {
   public $kind= 'method';
   public $name, $modifiers, $signature, $body, $holder;
 
-  public function __construct($modifiers, $name, $signature, $body= null, $annotations= [], $comment= null, $line= -1, $holder= null) {
+  public function __construct($modifiers, $name, $signature, $body= null, $annotations= null, $comment= null, $line= -1, $holder= null) {
     $this->name= $name;
     $this->modifiers= $modifiers;
     $this->signature= $signature;

--- a/src/main/php/lang/ast/nodes/Method.class.php
+++ b/src/main/php/lang/ast/nodes/Method.class.php
@@ -9,9 +9,9 @@ class Method extends Annotated implements Member {
     $this->modifiers= $modifiers;
     $this->signature= $signature;
     $this->body= $body;
-    $this->annotations= $annotations;
-    $this->line= $line;
+    $this->declared= $this->line= $line;
     $this->holder= $holder;
+    null === $annotations || $this->annotate($annotations);
     null === $comment || $this->attach($comment);
   }
 

--- a/src/main/php/lang/ast/nodes/Parameter.class.php
+++ b/src/main/php/lang/ast/nodes/Parameter.class.php
@@ -4,7 +4,7 @@ class Parameter extends Annotated {
   public $kind= 'parameter';
   public $name, $reference, $type, $variadic, $promote, $default, $annotations;
 
-  public function __construct($name, $type, $default= null, $reference= false, $variadic= false, $promote= null, $annotations= []) {
+  public function __construct($name, $type, $default= null, $reference= false, $variadic= false, $promote= null, $annotations= null) {
     $this->name= $name;
     $this->type= $type;
     $this->default= $default;

--- a/src/main/php/lang/ast/nodes/Property.class.php
+++ b/src/main/php/lang/ast/nodes/Property.class.php
@@ -4,7 +4,7 @@ class Property extends Annotated implements Member {
   public $kind= 'property';
   public $name, $modifiers, $expression, $type, $holder;
 
-  public function __construct($modifiers, $name, $type, $expression= null, $annotations= [], $comment= null, $line= -1, $holder= null) {
+  public function __construct($modifiers, $name, $type, $expression= null, $annotations= null, $comment= null, $line= -1, $holder= null) {
     $this->modifiers= $modifiers;
     $this->name= $name;
     $this->type= $type;

--- a/src/main/php/lang/ast/nodes/Property.class.php
+++ b/src/main/php/lang/ast/nodes/Property.class.php
@@ -9,9 +9,9 @@ class Property extends Annotated implements Member {
     $this->name= $name;
     $this->type= $type;
     $this->expression= $expression;
-    $this->annotations= $annotations;
-    $this->line= $line;
+    $this->declared= $this->line= $line;
     $this->holder= $holder;
+    null === $annotations || $this->annotate($annotations);
     null === $comment || $this->attach($comment);
   }
 

--- a/src/main/php/lang/ast/nodes/TypeDeclaration.class.php
+++ b/src/main/php/lang/ast/nodes/TypeDeclaration.class.php
@@ -6,14 +6,15 @@ abstract class TypeDeclaration extends Annotated {
   public function __construct($modifiers, $name, $body= [], $annotations= null, $comment= null, $line= -1) {
     $this->modifiers= $modifiers;
     $this->name= $name;
-    $this->annotations= $annotations;
-    $this->line= $line;
+    $this->declared= $this->line= $line;
     $this->body= [];
     foreach ($body as $lookup => $node) {
       $node->holder= $this->name;
       $this->body[$lookup]= $node;
     }
+    null === $annotations || $this->annotate($annotations);
     null === $comment || $this->attach($comment);
+
   }
 
   /** @return iterable */

--- a/src/main/php/lang/ast/nodes/TypeDeclaration.class.php
+++ b/src/main/php/lang/ast/nodes/TypeDeclaration.class.php
@@ -3,7 +3,7 @@
 abstract class TypeDeclaration extends Annotated {
   public $modifiers, $name, $body;
 
-  public function __construct($modifiers, $name, $body= [], $annotations= [], $comment= null, $line= -1) {
+  public function __construct($modifiers, $name, $body= [], $annotations= null, $comment= null, $line= -1) {
     $this->modifiers= $modifiers;
     $this->name= $name;
     $this->annotations= $annotations;

--- a/src/main/php/lang/ast/syntax/PHP.class.php
+++ b/src/main/php/lang/ast/syntax/PHP.class.php
@@ -311,7 +311,7 @@ class PHP extends Language {
         $type= $parse->token->value;
         $parse->forward();
       } else if ('class' === $parse->token->value) {
-        $annotations= [];
+        $annotations= null;
         $type= null;
         $parse->forward();
       } else if ('#[' === $parse->token->value) {
@@ -909,7 +909,7 @@ class PHP extends Language {
         } while (true);
       }
 
-      $decl= new InterfaceDeclaration([], $name, $parents, [], [], $comment, $token->line);
+      $decl= new InterfaceDeclaration([], $name, $parents, [], null, $comment, $token->line);
       $parse->expecting('{', 'interface');
       $decl->body= $this->typeBody($parse, $decl->name);
       $parse->expecting('}', 'interface');
@@ -924,7 +924,7 @@ class PHP extends Language {
       $name= $parse->scope->resolve($parse->token->value);
       $parse->forward();
 
-      $decl= new TraitDeclaration([], $name, [], [], $comment, $token->line);
+      $decl= new TraitDeclaration([], $name, [], null, $comment, $token->line);
       $parse->expecting('{', 'trait');
       $decl->body= $this->typeBody($parse, $decl->name);
       $parse->expecting('}', 'trait');
@@ -965,7 +965,7 @@ class PHP extends Language {
         $base= null;
       }
 
-      $decl= new EnumDeclaration([], $name, $base, $implements, [], [], $comment, $token->line);
+      $decl= new EnumDeclaration([], $name, $base, $implements, [], null, $comment, $token->line);
       $parse->expecting('{', 'enum');
       $decl->body= $this->typeBody($parse, $decl->name);
       $parse->expecting('}', 'enum');
@@ -1102,7 +1102,7 @@ class PHP extends Language {
       }
 
       $parse->forward();
-      $signature= $this->signature($parse, isset($meta[DETAIL_TARGET_ANNO]) ? $meta[DETAIL_TARGET_ANNO] : []);
+      $signature= $this->signature($parse);
 
       if ('{' === $parse->token->value) {          // Regular body
         $parse->forward();
@@ -1308,7 +1308,7 @@ class PHP extends Language {
     return $annotations;
   }
 
-  private function parameters($parse, $target) {
+  private function parameters($parse) {
     static $promotion= ['private' => true, 'protected' => true, 'public' => true];
 
     $parameters= [];
@@ -1317,7 +1317,7 @@ class PHP extends Language {
         $parse->forward();
         $annotations= $this->annotations($parse, 'parameter annotations');
       } else {
-        $annotations= [];
+        $annotations= null;
       }
 
       if ('name' === $parse->token->kind && isset($promotion[$parse->token->value])) {
@@ -1354,7 +1354,6 @@ class PHP extends Language {
       }
 
       $name= $parse->token->value;
-      if (isset($target[$name])) $annotations= array_merge($annotations, $target[$name]);
       $parse->forward();
 
       $default= null;
@@ -1421,10 +1420,10 @@ class PHP extends Language {
     return $body;
   }
 
-  public function signature($parse, $annotations= []) {
+  public function signature($parse) {
     $line= $parse->token->line;
     $parse->expecting('(', 'signature');
-    $parameters= $this->parameters($parse, $annotations);
+    $parameters= $this->parameters($parse);
     $parse->expecting(')', 'signature');
 
     if (':' === $parse->token->value) {
@@ -1473,7 +1472,7 @@ class PHP extends Language {
       } while (true);
     }
 
-    $decl= new ClassDeclaration($modifiers, $name, $parent, $implements, [], [], $comment, $line);
+    $decl= new ClassDeclaration($modifiers, $name, $parent, $implements, [], null, $comment, $line);
     $parse->expecting('{', 'class');
     $decl->body= $this->typeBody($parse, $decl->name);
     $parse->expecting('}', 'class');

--- a/src/main/php/lang/ast/syntax/PHP.class.php
+++ b/src/main/php/lang/ast/syntax/PHP.class.php
@@ -990,7 +990,7 @@ class PHP extends Language {
           $expr= null;
         }
 
-        $body[$name]= new EnumCase($name, $expr, $meta[DETAIL_ANNOTATIONS] ?? [], $comment, $line, $holder);
+        $body[$name]= new EnumCase($name, $expr, $meta[DETAIL_ANNOTATIONS] ?? null, $comment, $line, $holder);
       } while (',' === $parse->token->value && true | $parse->forward());
 
       $parse->expecting(';', 'case');
@@ -1073,7 +1073,7 @@ class PHP extends Language {
           $name,
           $type,
           $this->expression($parse, 0),
-          $meta[DETAIL_ANNOTATIONS] ?? [],
+          $meta[DETAIL_ANNOTATIONS] ?? null,
           $comment,
           $line,
           $holder
@@ -1121,7 +1121,7 @@ class PHP extends Language {
         $name,
         $signature,
         $statements,
-        $meta[DETAIL_ANNOTATIONS] ?? [],
+        $meta[DETAIL_ANNOTATIONS] ?? null,
         $comment,
         $line,
         $holder
@@ -1254,7 +1254,7 @@ class PHP extends Language {
   private function properties($parse, &$body, $meta, $modifiers, $type, $holder) {
     $comment= $parse->comment;
     $parse->comment= null;
-    $annotations= $meta[DETAIL_ANNOTATIONS] ?? [];
+    $annotations= $meta[DETAIL_ANNOTATIONS] ?? null;
 
     while (';' !== $parse->token->value) {
       $line= $parse->token->line;

--- a/src/main/php/lang/ast/syntax/PHP.class.php
+++ b/src/main/php/lang/ast/syntax/PHP.class.php
@@ -384,13 +384,6 @@ class PHP extends Language {
       return new UnpackExpression($this->expression($parse, 0), $token->line);
     });
 
-    $this->prefix('#[', 0, function($parse, $token) {
-      $annotations= $this->annotations($parse, 'annotations');
-      $expression= $this->expression($parse, 0);
-      $expression->annotations= $annotations;
-      return $expression;
-    });
-
     $this->prefix('fn', 0, function($parse, $token) {
       $signature= $this->signature($parse);
       $parse->expecting('=>', 'fn');
@@ -847,9 +840,7 @@ class PHP extends Language {
 
     $this->stmt('#[', function($parse, $token) {
       $annotations= $this->annotations($parse, 'annotations');
-      $type= $this->statement($parse);
-      $type->annotations= $annotations;
-      return $type;
+      return $this->statement($parse)->annotate($annotations);
     });
 
     $this->stmt('function', function($parse, $token) {

--- a/src/test/php/lang/ast/unittest/AnnotationsTest.class.php
+++ b/src/test/php/lang/ast/unittest/AnnotationsTest.class.php
@@ -71,6 +71,11 @@ class AnnotationsTest {
   }
 
   #[Test]
+  public function no_annotations_from_declaration() {
+    Assert::equals([], (new ClassDeclaration([], 'Test', null, [], [], null))->annotations());
+  }
+
+  #[Test]
   public function no_annotation_from_declaration() {
     Assert::null((new ClassDeclaration([], 'Test', null, [], [], null))->annotation(Test::class));
   }

--- a/src/test/php/lang/ast/unittest/AnnotationsTest.class.php
+++ b/src/test/php/lang/ast/unittest/AnnotationsTest.class.php
@@ -1,7 +1,7 @@
 <?php namespace lang\ast\unittest;
 
 use lang\ast\nodes\{Annotation, Annotations, ClassDeclaration};
-use unittest\{Assert, Test};
+use unittest\{Assert, Test, Values};
 
 class AnnotationsTest {
 
@@ -85,6 +85,24 @@ class AnnotationsTest {
     Assert::equals(
       new Annotation(Test::class, []),
       (new ClassDeclaration([], 'Test', null, [], [], new Annotations([Test::class => []])))->annotation(Test::class)
+    );
+  }
+
+  #[Test]
+  public function annotate_declaration() {
+    $declaration= new ClassDeclaration([], 'Test', null, [], [], new Annotations([Test::class => []]));
+    Assert::equals(
+      [Test::class => new Annotation(Test::class, []), Values::class => new Annotation(Values::class, [])],
+      $declaration->annotate(new Annotation(Values::class, []))->annotations()
+    );
+  }
+
+  #[Test]
+  public function annotate_declaration_without_annotations() {
+    $declaration= new ClassDeclaration([], 'Test', null, [], [], null);
+    Assert::equals(
+      [Test::class => new Annotation(Test::class, [])],
+      $declaration->annotate(new Annotation(Test::class, []))->annotations()
     );
   }
 }

--- a/src/test/php/lang/ast/unittest/AnnotationsTest.class.php
+++ b/src/test/php/lang/ast/unittest/AnnotationsTest.class.php
@@ -1,9 +1,15 @@
 <?php namespace lang\ast\unittest;
 
 use lang\ast\nodes\{Annotation, Annotations, ClassDeclaration};
-use unittest\{Assert, Test, Values};
+use unittest\{Assert, Before, Test, Values};
 
 class AnnotationsTest {
+  private $annotation;
+
+  #[Before]
+  public function annotation() {
+    $this->annotation= new Annotation(Test::class, []);
+  }
 
   #[Test]
   public function can_create() {
@@ -23,7 +29,7 @@ class AnnotationsTest {
   #[Test]
   public function all() {
     Assert::equals(
-      [Test::class => new Annotation(Test::class, [])],
+      [Test::class => $this->annotation],
       (new Annotations([Test::class => []]))->all()
     );
   }
@@ -37,18 +43,34 @@ class AnnotationsTest {
   }
 
   #[Test]
-  public function named() {
+  public function with_annotation() {
     Assert::equals(
-      new Annotation(Test::class, []),
+      $this->annotation,
+      (new Annotations($this->annotation))->named(Test::class)
+    );
+  }
+
+  #[Test]
+  public function with_named() {
+    Assert::equals(
+      $this->annotation,
       (new Annotations([Test::class => []]))->named(Test::class)
+    );
+  }
+
+  #[Test]
+  public function with_annotations() {
+    Assert::equals(
+      $this->annotation,
+      (new Annotations([Test::class => $this->annotation]))->named(Test::class)
     );
   }
 
   #[Test]
   public function add() {
     Assert::equals(
-      [Test::class => new Annotation(Test::class, [])],
-      (new Annotations())->add(new Annotation(Test::class, []))->all()
+      [Test::class => $this->annotation],
+      (new Annotations())->add($this->annotation)->all()
     );
   }
 
@@ -62,7 +84,7 @@ class AnnotationsTest {
   #[Test]
   public function removing_returns_removed_annotation() {
     $fixture= new Annotations([Test::class => []]);
-    Assert::equals(new Annotation(Test::class, []), $fixture->remove(Test::class));
+    Assert::equals($this->annotation, $fixture->remove(Test::class));
   }
 
   #[Test]
@@ -83,7 +105,7 @@ class AnnotationsTest {
   #[Test]
   public function annotation_from_declaration() {
     Assert::equals(
-      new Annotation(Test::class, []),
+      $this->annotation,
       (new ClassDeclaration([], 'Test', null, [], [], new Annotations([Test::class => []])))->annotation(Test::class)
     );
   }
@@ -92,7 +114,7 @@ class AnnotationsTest {
   public function annotate_declaration() {
     $declaration= new ClassDeclaration([], 'Test', null, [], [], new Annotations([Test::class => []]));
     Assert::equals(
-      [Test::class => new Annotation(Test::class, []), Values::class => new Annotation(Values::class, [])],
+      [Test::class => $this->annotation, Values::class => new Annotation(Values::class, [])],
       $declaration->annotate(new Annotation(Values::class, []))->annotations()
     );
   }
@@ -101,8 +123,17 @@ class AnnotationsTest {
   public function annotate_declaration_without_annotations() {
     $declaration= new ClassDeclaration([], 'Test', null, [], [], null);
     Assert::equals(
-      [Test::class => new Annotation(Test::class, [])],
-      $declaration->annotate(new Annotation(Test::class, []))->annotations()
+      [Test::class => $this->annotation],
+      $declaration->annotate($this->annotation)->annotations()
+    );
+  }
+
+  #[Test]
+  public function set_declarations_annotations() {
+    $declaration= new ClassDeclaration([], 'Test', null, [], [], null);
+    Assert::equals(
+      [Test::class => $this->annotation],
+      $declaration->annotate(new Annotations([Test::class => []]))->annotations()
     );
   }
 }

--- a/src/test/php/lang/ast/unittest/AnnotationsTest.class.php
+++ b/src/test/php/lang/ast/unittest/AnnotationsTest.class.php
@@ -1,20 +1,85 @@
 <?php namespace lang\ast\unittest;
 
-use lang\ast\nodes\{Annotation, ClassDeclaration};
+use lang\ast\nodes\{Annotation, Annotations, ClassDeclaration};
 use unittest\{Assert, Test};
 
 class AnnotationsTest {
 
   #[Test]
-  public function no_annotation() {
-    Assert::null((new ClassDeclaration([], 'Test', null, [], [], []))->annotation('value'));
+  public function can_create() {
+    new Annotations();
   }
 
   #[Test]
-  public function annotation_without_value() {
+  public function initially_empty() {
+    Assert::equals([], (new Annotations())->all());
+  }
+
+  #[Test]
+  public function non_existant() {
+    Assert::null((new Annotations())->named(Test::class));
+  }
+
+  #[Test]
+  public function all() {
     Assert::equals(
-      new Annotation('value', null),
-      (new ClassDeclaration([], 'Test', null, [], [], ['value' => null]))->annotation('value')
+      [Test::class => new Annotation(Test::class, [])],
+      (new Annotations([Test::class => []]))->all()
+    );
+  }
+
+  #[Test]
+  public function iteration() {
+    Assert::equals(
+      [Test::class => []],
+      iterator_to_array(new Annotations([Test::class => []]))
+    );
+  }
+
+  #[Test]
+  public function named() {
+    Assert::equals(
+      new Annotation(Test::class, []),
+      (new Annotations([Test::class => []]))->named(Test::class)
+    );
+  }
+
+  #[Test]
+  public function add() {
+    Assert::equals(
+      [Test::class => new Annotation(Test::class, [])],
+      (new Annotations())->add(new Annotation(Test::class, []))->all()
+    );
+  }
+
+  #[Test]
+  public function remove() {
+    $fixture= new Annotations([Test::class => []]);
+    $fixture->remove(Test::class);
+    Assert::equals([], $fixture->all());
+  }
+
+  #[Test]
+  public function removing_returns_removed_annotation() {
+    $fixture= new Annotations([Test::class => []]);
+    Assert::equals(new Annotation(Test::class, []), $fixture->remove(Test::class));
+  }
+
+  #[Test]
+  public function removing_returns_null_if_nothing_as_rempved() {
+    Assert::null((new Annotations())->remove(Test::class));
+  }
+
+  #[Test]
+  public function no_annotation_from_declaration() {
+    Assert::null((new ClassDeclaration([], 'Test', null, [], [], null))->annotation(Test::class));
+  }
+
+  #[Test]
+  public function annotation_from_declaration() {
+    Assert::equals(
+      new Annotation(Test::class, []),
+      (new ClassDeclaration([], 'Test', null, [], [], new Annotations([Test::class => []])))->annotation(Test::class)
     );
   }
 }

--- a/src/test/php/lang/ast/unittest/ClassTest.class.php
+++ b/src/test/php/lang/ast/unittest/ClassTest.class.php
@@ -29,7 +29,7 @@ class ClassTest {
 
   #[Test]
   public function overwrite() {
-    $overwritten= new Method([], 'toString', new Signature([], null), [], [], 'Overwritten');
+    $overwritten= new Method([], 'toString', new Signature([], null), [], null, 'Overwritten');
 
     $fixture= new ClassDeclaration([], 'Test', null, [], [], null);
     $fixture->declare($this->method);
@@ -40,7 +40,7 @@ class ClassTest {
 
   #[Test]
   public function declare() {
-    $overwritten= new Method([], 'toString', new Signature([], null), [], [], 'Overwritten');
+    $overwritten= new Method([], 'toString', new Signature([], null), [], null, 'Overwritten');
 
     $fixture= new ClassDeclaration([], 'Test', null, [], [], null);
     $fixture->declare($this->method);

--- a/src/test/php/lang/ast/unittest/parse/AttributesTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/AttributesTest.class.php
@@ -36,7 +36,7 @@ class AttributesTest extends ParseTest {
    * @return void
    */
   private function assertAnnotated($expected, $node) {
-    Assert::equals($expected, cast($node, Annotated::class)->annotations);
+    Assert::equals($expected, iterator_to_array(cast($node, Annotated::class)->annotations));
   }
 
   #[Test]

--- a/src/test/php/lang/ast/unittest/parse/ClosuresTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/ClosuresTest.class.php
@@ -30,7 +30,7 @@ class ClosuresTest extends ParseTest {
 
   #[Test]
   public function with_param() {
-    $params= [new Parameter('a', null, null, false, false, null, [])];
+    $params= [new Parameter('a', null, null, false, false, null, null)];
     $this->assertParsed(
       [new ClosureExpression(new Signature($params, null, self::LINE), null, [$this->returns], self::LINE)],
       'function($a) { return $a + 1; };'

--- a/src/test/php/lang/ast/unittest/parse/CommentTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/CommentTest.class.php
@@ -94,14 +94,14 @@ class CommentTest extends ParseTest {
 
   #[Test]
   public function apidoc_comment_after_class_name_discarded() {
-    $this->assertParsed([new ClassDeclaration([], '\\T', null, [], [], [], null, 2)], '
+    $this->assertParsed([new ClassDeclaration([], '\\T', null, [], [], null, null, 2)], '
       class T /** Discarded */ { }
     ');
   }
 
   #[Test]
   public function apidoc_comment_attached_to_next_node() {
-    $this->assertParsed([new ClassDeclaration([], '\\T', null, [], [], [], new Comment('/** @api */', 2), 3)], '
+    $this->assertParsed([new ClassDeclaration([], '\\T', null, [], [], null, new Comment('/** @api */', 2), 3)], '
       /** @api */
       class T { }
     ');
@@ -118,8 +118,8 @@ class CommentTest extends ParseTest {
 
   #[Test]
   public function apidoc_comment_attached_to_next_constant() {
-    $class= new ClassDeclaration([], '\\T', null, [], [], [], null, 2);
-    $class->declare(new Constant(['public'], 'FIXTURE', null, new Literal('1', 4), [], new Comment('/** @api */', 3), 4));
+    $class= new ClassDeclaration([], '\\T', null, [], [], null, null, 2);
+    $class->declare(new Constant(['public'], 'FIXTURE', null, new Literal('1', 4), null, new Comment('/** @api */', 3), 4));
 
     $this->assertParsed([$class], '
       class T {
@@ -131,8 +131,8 @@ class CommentTest extends ParseTest {
 
   #[Test]
   public function apidoc_comment_attached_to_next_property() {
-    $class= new ClassDeclaration([], '\\T', null, [], [], [], null, 2);
-    $class->declare(new Property(['public'], 'fixture', null, null, [], new Comment('/** @api */', 3), 4));
+    $class= new ClassDeclaration([], '\\T', null, [], [], null, null, 2);
+    $class->declare(new Property(['public'], 'fixture', null, null, null, new Comment('/** @api */', 3), 4));
 
     $this->assertParsed([$class], '
       class T {
@@ -144,8 +144,8 @@ class CommentTest extends ParseTest {
 
   #[Test]
   public function apidoc_comment_attached_to_next_method() {
-    $class= new ClassDeclaration([], '\\T', null, [], [], [], null, 2);
-    $class->declare(new Method(['public'], '__construct', new Signature([], null, 4), [], [], new Comment('/** @api */', 3), 3));
+    $class= new ClassDeclaration([], '\\T', null, [], [], null, null, 2);
+    $class->declare(new Method(['public'], '__construct', new Signature([], null, 4), [], null, new Comment('/** @api */', 3), 3));
 
     $this->assertParsed([$class], '
       class T {

--- a/src/test/php/lang/ast/unittest/parse/CommentTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/CommentTest.class.php
@@ -1,6 +1,6 @@
 <?php namespace lang\ast\unittest\parse;
 
-use lang\ast\nodes\{ClassDeclaration, Comment, Constant, Property, Method, Signature, Literal};
+use lang\ast\nodes\{Annotations, ClassDeclaration, Comment, Constant, Property, Method, Signature, Literal};
 use unittest\{Assert, Test};
 
 class CommentTest extends ParseTest {
@@ -109,7 +109,7 @@ class CommentTest extends ParseTest {
 
   #[Test]
   public function apidoc_comment_and_annotations() {
-    $this->assertParsed([new ClassDeclaration([], '\\T', null, [], [], ['Test' => []], new Comment('/** @api */', 2), 4)], '
+    $this->assertParsed([new ClassDeclaration([], '\\T', null, [], [], new Annotations(['Test' => []], 3), new Comment('/** @api */', 2), 4)], '
       /** @api */
       #[Test]
       class T { }

--- a/src/test/php/lang/ast/unittest/parse/CommentTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/CommentTest.class.php
@@ -145,7 +145,7 @@ class CommentTest extends ParseTest {
   #[Test]
   public function apidoc_comment_attached_to_next_method() {
     $class= new ClassDeclaration([], '\\T', null, [], [], null, null, 2);
-    $class->declare(new Method(['public'], '__construct', new Signature([], null, 4), [], null, new Comment('/** @api */', 3), 3));
+    $class->declare(new Method(['public'], '__construct', new Signature([], null, 4), [], null, new Comment('/** @api */', 3), 4));
 
     $this->assertParsed([$class], '
       class T {

--- a/src/test/php/lang/ast/unittest/parse/ErrorsTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/ErrorsTest.class.php
@@ -75,7 +75,7 @@ class ErrorsTest extends ParseTest {
   #[Test]
   public function unclosed_annotation() {
     $this->assertError(
-      'Expected "]", have "(end)" in attributes',
+      'Expected "]", have "(end)" in annotations',
       $this->parse('#[Annotation')
     );
   }

--- a/src/test/php/lang/ast/unittest/parse/FunctionsTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/FunctionsTest.class.php
@@ -54,7 +54,7 @@ class FunctionsTest extends ParseTest {
 
   #[Test, Values(['param', 'protected'])]
   public function with_parameter($name) {
-    $params= [new Parameter($name, null, null, false, false, null, [])];
+    $params= [new Parameter($name, null, null, false, false, null, null)];
     $this->assertParsed(
       [new FunctionDeclaration('a', new Signature($params, null, self::LINE), [], self::LINE)],
       'function a($'.$name.') { }'
@@ -63,7 +63,7 @@ class FunctionsTest extends ParseTest {
 
   #[Test]
   public function with_reference_parameter() {
-    $params= [new Parameter('param', null, null, true, false, null, [])];
+    $params= [new Parameter('param', null, null, true, false, null, null)];
     $this->assertParsed(
       [new FunctionDeclaration('a', new Signature($params, null, self::LINE), [], self::LINE)],
       'function a(&$param) { }'
@@ -72,7 +72,7 @@ class FunctionsTest extends ParseTest {
 
   #[Test]
   public function dangling_comma_in_parameter_lists() {
-    $params= [new Parameter('param', null, null, false, false, null, [])];
+    $params= [new Parameter('param', null, null, false, false, null, null)];
     $this->assertParsed(
       [new FunctionDeclaration('a', new Signature($params, null, self::LINE), [], self::LINE)],
       'function a($param, ) { }'
@@ -81,7 +81,7 @@ class FunctionsTest extends ParseTest {
 
   #[Test, Values('types')]
   public function with_typed_parameter($declaration, $expected) {
-    $params= [new Parameter('param', $expected, null, false, false, null, [])];
+    $params= [new Parameter('param', $expected, null, false, false, null, null)];
     $this->assertParsed(
       [new FunctionDeclaration('a', new Signature($params, null, self::LINE), [], self::LINE)],
       'function a('.$declaration.' $param) { }'
@@ -90,7 +90,7 @@ class FunctionsTest extends ParseTest {
 
   #[Test]
   public function with_nullable_typed_parameter() {
-    $params= [new Parameter('param', new IsNullable(new IsLiteral('string')), null, false, false, null, [])];
+    $params= [new Parameter('param', new IsNullable(new IsLiteral('string')), null, false, false, null, null)];
     $this->assertParsed(
       [new FunctionDeclaration('a', new Signature($params, null, self::LINE), [], self::LINE)],
       'function a(?string $param) { }'
@@ -99,7 +99,7 @@ class FunctionsTest extends ParseTest {
 
   #[Test]
   public function with_variadic_parameter() {
-    $params= [new Parameter('param', null, null, false, true, null, [])];
+    $params= [new Parameter('param', null, null, false, true, null, null)];
     $this->assertParsed(
       [new FunctionDeclaration('a', new Signature($params, null, self::LINE), [], self::LINE)],
       'function a(... $param) { }'
@@ -108,7 +108,7 @@ class FunctionsTest extends ParseTest {
 
   #[Test]
   public function with_optional_parameter() {
-    $params= [new Parameter('param', null, new Literal('null', self::LINE), false, false, null, [])];
+    $params= [new Parameter('param', null, new Literal('null', self::LINE), false, false, null, null)];
     $this->assertParsed(
       [new FunctionDeclaration('a', new Signature($params, null, self::LINE), [], self::LINE)],
       'function a($param= null) { }'
@@ -117,7 +117,7 @@ class FunctionsTest extends ParseTest {
 
   #[Test]
   public function with_parameter_named_function() {
-    $params= [new Parameter('function', null, null, false, false, null, [])];
+    $params= [new Parameter('function', null, null, false, false, null, null)];
     $this->assertParsed(
       [new FunctionDeclaration('a', new Signature($params, null, self::LINE), [], self::LINE)],
       'function a($function, ) { }'
@@ -126,7 +126,7 @@ class FunctionsTest extends ParseTest {
 
   #[Test]
   public function with_typed_parameter_named_function() {
-    $params= [new Parameter('function', new IsFunction([], new IsLiteral('void')), null, false, false, null, [])];
+    $params= [new Parameter('function', new IsFunction([], new IsLiteral('void')), null, false, false, null, null)];
     $this->assertParsed(
       [new FunctionDeclaration('a', new Signature($params, null, self::LINE), [], self::LINE)],
       'function a((function(): void) $function) { }'

--- a/src/test/php/lang/ast/unittest/parse/MembersTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/MembersTest.class.php
@@ -36,75 +36,75 @@ class MembersTest extends ParseTest {
 
   #[Test]
   public function private_instance_property() {
-    $class= new ClassDeclaration([], '\\A', null, [], [], [], null, self::LINE);
-    $class->declare(new Property(['private'], 'a', null, null, [], null, self::LINE));
+    $class= new ClassDeclaration([], '\\A', null, [], [], null, null, self::LINE);
+    $class->declare(new Property(['private'], 'a', null, null, null, null, self::LINE));
 
     $this->assertParsed([$class], 'class A { private $a; }');
   }
 
   #[Test]
   public function private_instance_properties() {
-    $class= new ClassDeclaration([], '\\A', null, [], [], [], null, self::LINE);
-    $class->declare(new Property(['private'], 'a', null, null, [], null, self::LINE));
-    $class->declare(new Property(['private'], 'b', null, null, [], null, self::LINE));
+    $class= new ClassDeclaration([], '\\A', null, [], [], null, null, self::LINE);
+    $class->declare(new Property(['private'], 'a', null, null, null, null, self::LINE));
+    $class->declare(new Property(['private'], 'b', null, null, null, null, self::LINE));
 
     $this->assertParsed([$class], 'class A { private $a, $b; }');
   }
 
   #[Test]
   public function private_instance_method() {
-    $class= new ClassDeclaration([], '\\A', null, [], [], [], null, self::LINE);
-    $class->declare(new Method(['private'], 'a', new Signature([], null, self::LINE), [], [], null, self::LINE));
+    $class= new ClassDeclaration([], '\\A', null, [], [], null, null, self::LINE);
+    $class->declare(new Method(['private'], 'a', new Signature([], null, self::LINE), [], null, null, self::LINE));
 
     $this->assertParsed([$class], 'class A { private function a() { } }');
   }
 
   #[Test]
   public function private_static_method() {
-    $class= new ClassDeclaration([], '\\A', null, [], [], [], null, self::LINE);
-    $class->declare(new Method(['private', 'static'], 'a', new Signature([], null, self::LINE), [], [], null, self::LINE));
+    $class= new ClassDeclaration([], '\\A', null, [], [], null, null, self::LINE);
+    $class->declare(new Method(['private', 'static'], 'a', new Signature([], null, self::LINE), [], null, null, self::LINE));
 
     $this->assertParsed([$class], 'class A { private static function a() { } }');
   }
 
   #[Test]
   public function class_constant() {
-    $class= new ClassDeclaration([], '\\A', null, [], [], [], null, self::LINE);
-    $class->declare(new Constant([], 'T', null, new Literal('1', self::LINE), [], null, self::LINE));
+    $class= new ClassDeclaration([], '\\A', null, [], [], null, null, self::LINE);
+    $class->declare(new Constant([], 'T', null, new Literal('1', self::LINE), null, null, self::LINE));
 
     $this->assertParsed([$class], 'class A { const T = 1; }');
   }
 
   #[Test]
   public function class_constants() {
-    $class= new ClassDeclaration([], '\\A', null, [], [], [], null, self::LINE);
-    $class->declare(new Constant([], 'T', null, new Literal('1', self::LINE), [], null, self::LINE));
-    $class->declare(new Constant([], 'S', null, new Literal('2', self::LINE), [], null, self::LINE));
+    $class= new ClassDeclaration([], '\\A', null, [], [], null, null, self::LINE);
+    $class->declare(new Constant([], 'T', null, new Literal('1', self::LINE), null, null, self::LINE));
+    $class->declare(new Constant([], 'S', null, new Literal('2', self::LINE), null, null, self::LINE));
 
     $this->assertParsed([$class], 'class A { const T = 1, S = 2; }');
   }
 
   #[Test]
   public function private_class_constant() {
-    $class= new ClassDeclaration([], '\\A', null, [], [], [], null, self::LINE);
-    $class->declare(new Constant(['private'], 'T', null, new Literal('1', self::LINE), [], null, self::LINE));
+    $class= new ClassDeclaration([], '\\A', null, [], [], null, null, self::LINE);
+    $class->declare(new Constant(['private'], 'T', null, new Literal('1', self::LINE), null, null, self::LINE));
 
     $this->assertParsed([$class], 'class A { private const T = 1; }');
   }
 
   #[Test, Values('types')]
   public function method_with_typed_parameter($declaration, $expected) {
-    $class= new ClassDeclaration([], '\\A', null, [], [], [], null, self::LINE);
-    $params= [new Parameter('param', $expected, null, false, false, null, [])];
-    $class->declare(new Method(['public'], 'a', new Signature($params, null, self::LINE), [], [], null, self::LINE));
+    $class= new ClassDeclaration([], '\\A', null, [], [], null, null, self::LINE);
+    $params= [new Parameter('param', $expected, null, false, false, null, null)];
+    $class->declare(new Method(['public'], 'a', new Signature($params, null, self::LINE), [], null, null, self::LINE));
 
     $this->assertParsed([$class], 'class A { public function a('.$declaration.' $param) { } }');
   }
 
   #[Test, Values('types')]
   public function method_with_return_type($declaration, $expected) {
-    $class= new ClassDeclaration([], '\\A', null, [], [], [], null, self::LINE);
-    $class->declare(new Method(['public'], 'a', new Signature([], $expected, self::LINE), [], [], null, self::LINE));
+    $class= new ClassDeclaration([], '\\A', null, [], [], null, null, self::LINE);
+    $class->declare(new Method(['public'], 'a', new Signature([], $expected, self::LINE), [], null, null, self::LINE));
 
     $this->assertParsed([$class], 'class A { public function a(): '.$declaration.' { } }');
   }
@@ -112,7 +112,7 @@ class MembersTest extends ParseTest {
   #[Test]
   public function method_with_annotation() {
     $annotations= new Annotations(['Test' => []], self::LINE);
-    $class= new ClassDeclaration([], '\\A', null, [], [], [], null, self::LINE);
+    $class= new ClassDeclaration([], '\\A', null, [], [], null, null, self::LINE);
     $class->declare(new Method(['public'], 'a', new Signature([], null, self::LINE), [], $annotations, null, self::LINE));
 
     $this->assertParsed([$class], 'class A { #[Test] public function a() { } }');
@@ -121,7 +121,7 @@ class MembersTest extends ParseTest {
   #[Test]
   public function method_with_annotations() {
     $annotations= new Annotations(['Test' => [], 'Ignore' => [new Literal('"Not implemented"', self::LINE)]], self::LINE);
-    $class= new ClassDeclaration([], '\\A', null, [], [], [], null, self::LINE);
+    $class= new ClassDeclaration([], '\\A', null, [], [], null, null, self::LINE);
     $class->declare(new Method(['public'], 'a', new Signature([], null, self::LINE), [], $annotations, null, self::LINE));
 
     $this->assertParsed([$class], 'class A { #[Test, Ignore("Not implemented")] public function a() { } }');
@@ -214,52 +214,52 @@ class MembersTest extends ParseTest {
 
   #[Test]
   public function typed_property() {
-    $class= new ClassDeclaration([], '\\A', null, [], [], [], null, self::LINE);
-    $class->declare(new Property(['private'], 'a', new Type('string'), null, [], null, self::LINE));
+    $class= new ClassDeclaration([], '\\A', null, [], [], null, null, self::LINE);
+    $class->declare(new Property(['private'], 'a', new Type('string'), null, null, null, self::LINE));
 
     $this->assertParsed([$class], 'class A { private string $a; }');
   }
 
   #[Test]
   public function typed_property_with_value() {
-    $class= new ClassDeclaration([], '\\A', null, [], [], [], null, self::LINE);
-    $class->declare(new Property(['private'], 'a', new Type('string'), new Literal('"test"', self::LINE), [], null, self::LINE));
+    $class= new ClassDeclaration([], '\\A', null, [], [], null, null, self::LINE);
+    $class->declare(new Property(['private'], 'a', new Type('string'), new Literal('"test"', self::LINE), null, null, self::LINE));
 
     $this->assertParsed([$class], 'class A { private string $a = "test"; }');
   }
 
   #[Test]
   public function typed_properties() {
-    $class= new ClassDeclaration([], '\\A', null, [], [], [], null, self::LINE);
-    $class->declare(new Property(['private'], 'a', new Type('string'), null, [], null, self::LINE));
-    $class->declare(new Property(['private'], 'b', new Type('string'), null, [], null, self::LINE));
-    $class->declare(new Property(['private'], 'c', new Type('int'), null, [], null, self::LINE));
+    $class= new ClassDeclaration([], '\\A', null, [], [], null, null, self::LINE);
+    $class->declare(new Property(['private'], 'a', new Type('string'), null, null, null, self::LINE));
+    $class->declare(new Property(['private'], 'b', new Type('string'), null, null, null, self::LINE));
+    $class->declare(new Property(['private'], 'c', new Type('int'), null, null, null, self::LINE));
 
     $this->assertParsed([$class], 'class A { private string $a, $b, int $c; }');
   }
 
   #[Test]
   public function readonly_property() {
-    $class= new ClassDeclaration([], '\\A', null, [], [], [], null, self::LINE);
-    $class->declare(new Property(['public', 'readonly'], 'a', new Type('int'), null, [], null, self::LINE));
+    $class= new ClassDeclaration([], '\\A', null, [], [], null, null, self::LINE);
+    $class->declare(new Property(['public', 'readonly'], 'a', new Type('int'), null, null, null, self::LINE));
 
     $this->assertParsed([$class], 'class A { public readonly int $a; }');
   }
 
   #[Test]
   public function typed_constant() {
-    $class= new ClassDeclaration([], '\\A', null, [], [], [], null, self::LINE);
-    $class->declare(new Constant([], 'T', new Type('int'), new Literal('1', self::LINE), [], null, self::LINE));
+    $class= new ClassDeclaration([], '\\A', null, [], [], null, null, self::LINE);
+    $class->declare(new Constant([], 'T', new Type('int'), new Literal('1', self::LINE), null, null, self::LINE));
 
     $this->assertParsed([$class], 'class A { const int T = 1; }');
   }
 
   #[Test]
   public function typed_constants() {
-    $class= new ClassDeclaration([], '\\A', null, [], [], [], null, self::LINE);
-    $class->declare(new Constant([], 'T', new Type('int'), new Literal('1', self::LINE), [], null, self::LINE));
-    $class->declare(new Constant([], 'S', new Type('int'), new Literal('2', self::LINE), [], null, self::LINE));
-    $class->declare(new Constant([], 'I', new Type('string'), new Literal('"i"', self::LINE), [], null, self::LINE));
+    $class= new ClassDeclaration([], '\\A', null, [], [], null, null, self::LINE);
+    $class->declare(new Constant([], 'T', new Type('int'), new Literal('1', self::LINE), null, null, self::LINE));
+    $class->declare(new Constant([], 'S', new Type('int'), new Literal('2', self::LINE), null, null, self::LINE));
+    $class->declare(new Constant([], 'I', new Type('string'), new Literal('"i"', self::LINE), null, null, self::LINE));
 
     $this->assertParsed([$class], 'class A { const int T = 1, S = 2, string I = "i"; }');
   }

--- a/src/test/php/lang/ast/unittest/parse/MembersTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/MembersTest.class.php
@@ -1,7 +1,20 @@
 <?php namespace lang\ast\unittest\parse;
 
 use lang\ast\Type;
-use lang\ast\nodes\{ClassDeclaration, Constant, InstanceExpression, InvokeExpression, Literal, Method, Property, ScopeExpression, Signature, Variable, Parameter};
+use lang\ast\nodes\{
+  Annotations,
+  ClassDeclaration,
+  Constant,
+  InstanceExpression,
+  InvokeExpression,
+  Literal,
+  Method,
+  Property,
+  ScopeExpression,
+  Signature,
+  Variable,
+  Parameter
+};
 use lang\ast\types\{IsFunction, IsLiteral, IsNullable, IsUnion, IsValue};
 use unittest\{Assert, Test, Values};
 
@@ -98,7 +111,7 @@ class MembersTest extends ParseTest {
 
   #[Test]
   public function method_with_annotation() {
-    $annotations= ['Test' => []];
+    $annotations= new Annotations(['Test' => []], self::LINE);
     $class= new ClassDeclaration([], '\\A', null, [], [], [], null, self::LINE);
     $class->declare(new Method(['public'], 'a', new Signature([], null, self::LINE), [], $annotations, null, self::LINE));
 
@@ -107,7 +120,7 @@ class MembersTest extends ParseTest {
 
   #[Test]
   public function method_with_annotations() {
-    $annotations= ['Test' => [], 'Ignore' => [new Literal('"Not implemented"', self::LINE)]];
+    $annotations= new Annotations(['Test' => [], 'Ignore' => [new Literal('"Not implemented"', self::LINE)]], self::LINE);
     $class= new ClassDeclaration([], '\\A', null, [], [], [], null, self::LINE);
     $class->declare(new Method(['public'], 'a', new Signature([], null, self::LINE), [], $annotations, null, self::LINE));
 

--- a/src/test/php/lang/ast/unittest/parse/NamedArgumentsTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/NamedArgumentsTest.class.php
@@ -64,9 +64,9 @@ class NamedArgumentsTest extends ParseTest {
   }
 
   #[Test]
-  public function attributes() {
+  public function annotations() {
     $node= $this->parse('#[Values(using: "$values")] class T { }')->tree()->children()[0];
-    $this->assertNamed(['using'], $node->annotations['Values']);
+    $this->assertNamed(['using'], $node->annotations->named('Values')->arguments);
   }
 
   #[Test]

--- a/src/test/php/lang/ast/unittest/parse/OperatorTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/OperatorTest.class.php
@@ -169,7 +169,7 @@ class OperatorTest extends ParseTest {
 
   #[Test]
   public function new_anonymous_extends() {
-    $declaration= new ClassDeclaration([], null, '\\T', [], [], [], null, self::LINE);
+    $declaration= new ClassDeclaration([], null, '\\T', [], [], null, null, self::LINE);
     $this->assertParsed(
       [new NewClassExpression($declaration, [], self::LINE)],
       'new class() extends T { };'
@@ -178,7 +178,7 @@ class OperatorTest extends ParseTest {
 
   #[Test]
   public function new_anonymous_implements() {
-    $declaration= new ClassDeclaration([], null, null, ['\\A', '\\B'], [], [], null, self::LINE);
+    $declaration= new ClassDeclaration([], null, null, ['\\A', '\\B'], [], null, null, self::LINE);
     $this->assertParsed(
       [new NewClassExpression($declaration, [], self::LINE)],
       'new class() implements A, B { };'

--- a/src/test/php/lang/ast/unittest/parse/TypesTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/TypesTest.class.php
@@ -18,7 +18,7 @@ class TypesTest extends ParseTest {
   #[Test]
   public function empty_class() {
     $this->assertParsed(
-      [new ClassDeclaration([], '\\A', null, [], [], [], null, self::LINE)],
+      [new ClassDeclaration([], '\\A', null, [], [], null, null, self::LINE)],
       'class A { }'
     );
   }
@@ -26,7 +26,7 @@ class TypesTest extends ParseTest {
   #[Test]
   public function class_with_parent() {
     $this->assertParsed(
-      [new ClassDeclaration([], '\\A', '\\B', [], [], [], null, self::LINE)],
+      [new ClassDeclaration([], '\\A', '\\B', [], [], null, null, self::LINE)],
       'class A extends B { }'
     );
   }
@@ -34,7 +34,7 @@ class TypesTest extends ParseTest {
   #[Test]
   public function class_with_interface() {
     $this->assertParsed(
-      [new ClassDeclaration([], '\\A', null, ['\\C'], [], [], null, self::LINE)],
+      [new ClassDeclaration([], '\\A', null, ['\\C'], [], null, null, self::LINE)],
       'class A implements C { }'
     );
   }
@@ -42,7 +42,7 @@ class TypesTest extends ParseTest {
   #[Test]
   public function class_with_interfaces() {
     $this->assertParsed(
-      [new ClassDeclaration([], '\\A', null, ['\\C', '\\D'], [], [], null, self::LINE)],
+      [new ClassDeclaration([], '\\A', null, ['\\C', '\\D'], [], null, null, self::LINE)],
       'class A implements C, D { }'
     );
   }
@@ -50,7 +50,7 @@ class TypesTest extends ParseTest {
   #[Test]
   public function abstract_class() {
     $this->assertParsed(
-      [new ClassDeclaration(['abstract'], '\\A', null, [], [], [], null, self::LINE)],
+      [new ClassDeclaration(['abstract'], '\\A', null, [], [], null, null, self::LINE)],
       'abstract class A { }'
     );
   }
@@ -58,7 +58,7 @@ class TypesTest extends ParseTest {
   #[Test]
   public function final_class() {
     $this->assertParsed(
-      [new ClassDeclaration(['final'], '\\A', null, [], [], [], null, self::LINE)],
+      [new ClassDeclaration(['final'], '\\A', null, [], [], null, null, self::LINE)],
       'final class A { }'
     );
   }
@@ -66,7 +66,7 @@ class TypesTest extends ParseTest {
   #[Test]
   public function empty_interface() {
     $this->assertParsed(
-      [new InterfaceDeclaration([], '\\A', [], [], [], null, self::LINE)],
+      [new InterfaceDeclaration([], '\\A', [], [], null, null, self::LINE)],
       'interface A { }'
     );
   }
@@ -74,7 +74,7 @@ class TypesTest extends ParseTest {
   #[Test]
   public function interface_with_parent() {
     $this->assertParsed(
-      [new InterfaceDeclaration([], '\\A', ['\\B'], [], [], null, self::LINE)],
+      [new InterfaceDeclaration([], '\\A', ['\\B'], [], null, null, self::LINE)],
       'interface A extends B { }'
     );
   }
@@ -82,7 +82,7 @@ class TypesTest extends ParseTest {
   #[Test]
   public function interface_with_parents() {
     $this->assertParsed(
-      [new InterfaceDeclaration([], '\\A', ['\\B', '\\C'], [], [], null, self::LINE)],
+      [new InterfaceDeclaration([], '\\A', ['\\B', '\\C'], [], null, null, self::LINE)],
       'interface A extends B, C { }'
     );
   }
@@ -90,7 +90,7 @@ class TypesTest extends ParseTest {
   #[Test]
   public function empty_trait() {
     $this->assertParsed(
-      [new TraitDeclaration([], '\\A', [], [], null, self::LINE)],
+      [new TraitDeclaration([], '\\A', [], null, null, self::LINE)],
       'trait A { }'
     );
   }
@@ -98,7 +98,7 @@ class TypesTest extends ParseTest {
   #[Test]
   public function empty_unit_enum() {
     $this->assertParsed(
-      [new EnumDeclaration([], '\\A', null, [], [], [], null, self::LINE)],
+      [new EnumDeclaration([], '\\A', null, [], [], null, null, self::LINE)],
       'enum A { }'
     );
   }
@@ -106,45 +106,45 @@ class TypesTest extends ParseTest {
   #[Test]
   public function empty_backed_enum() {
     $this->assertParsed(
-      [new EnumDeclaration([], '\\A', 'string', [], [], [], null, self::LINE)],
+      [new EnumDeclaration([], '\\A', 'string', [], [], null, null, self::LINE)],
       'enum A: string { }'
     );
   }
 
   #[Test]
   public function unit_enum_with_cases() {
-    $enum= new EnumDeclaration([], '\\A', null, [], [], [], null, self::LINE);
-    $enum->declare(new EnumCase('ONE', null, [], null, self::LINE));
-    $enum->declare(new EnumCase('TWO', null, [], null, self::LINE));
+    $enum= new EnumDeclaration([], '\\A', null, [], [], null, null, self::LINE);
+    $enum->declare(new EnumCase('ONE', null, null, null, self::LINE));
+    $enum->declare(new EnumCase('TWO', null, null, null, self::LINE));
     $this->assertParsed([$enum], 'enum A { case ONE; case TWO; }');
   }
 
   #[Test]
   public function backed_enum_with_cases() {
-    $enum= new EnumDeclaration([], '\\A', 'int', [], [], [], null, self::LINE);
-    $enum->declare(new EnumCase('ONE', new Literal('1', self::LINE), [], null, self::LINE));
-    $enum->declare(new EnumCase('TWO', new Literal('2', self::LINE), [], null, self::LINE));
+    $enum= new EnumDeclaration([], '\\A', 'int', [], [], null, null, self::LINE);
+    $enum->declare(new EnumCase('ONE', new Literal('1', self::LINE), null, null, self::LINE));
+    $enum->declare(new EnumCase('TWO', new Literal('2', self::LINE), null, null, self::LINE));
     $this->assertParsed([$enum], 'enum A: int { case ONE = 1; case TWO = 2; }');
   }
 
   #[Test]
   public function unit_enum_with_grouped_cases() {
-    $enum= new EnumDeclaration([], '\\A', null, [], [], [], null, self::LINE);
-    $enum->declare(new EnumCase('ONE', null, [], null, self::LINE));
-    $enum->declare(new EnumCase('TWO', null, [], null, self::LINE));
+    $enum= new EnumDeclaration([], '\\A', null, [], [], null, null, self::LINE);
+    $enum->declare(new EnumCase('ONE', null, null, null, self::LINE));
+    $enum->declare(new EnumCase('TWO', null, null, null, self::LINE));
     $this->assertParsed([$enum], 'enum A { case ONE, TWO; }');
   }
 
   #[Test]
   public function class_with_trait() {
-    $class= new ClassDeclaration([], '\\A', null, [], [], [], null, self::LINE);
+    $class= new ClassDeclaration([], '\\A', null, [], [], null, null, self::LINE);
     $class->body[]= new UseExpression(['\\B'], [], self::LINE);
     $this->assertParsed([$class], 'class A { use B; }');
   }
 
   #[Test]
   public function class_with_multiple_traits() {
-    $class= new ClassDeclaration([], '\\A', null, [], [], [], null, self::LINE);
+    $class= new ClassDeclaration([], '\\A', null, [], [], null, null, self::LINE);
     $class->body[]= new UseExpression(['\\B'], [], self::LINE);
     $class->body[]= new UseExpression(['\\C'], [], self::LINE);
     $this->assertParsed([$class], 'class A { use B; use C; }');
@@ -152,7 +152,7 @@ class TypesTest extends ParseTest {
 
   #[Test]
   public function class_with_comma_separated_traits() {
-    $class= new ClassDeclaration([], '\\A', null, [], [], [], null, self::LINE);
+    $class= new ClassDeclaration([], '\\A', null, [], [], null, null, self::LINE);
     $class->body[]= new UseExpression(['\\B', '\\C'], [], self::LINE);
     $this->assertParsed([$class], 'class A { use B, C; }');
   }
@@ -160,7 +160,7 @@ class TypesTest extends ParseTest {
   #[Test]
   public function class_with_trait_and_aliases() {
     $aliases= ['a' => ['as' => 'first'], '\\B::b' => ['as' => 'second'], '\\C::c' => ['insteadof' => '\\B']];
-    $class= new ClassDeclaration([], '\\A', null, [], [], [], null, self::LINE);
+    $class= new ClassDeclaration([], '\\A', null, [], [], null, null, self::LINE);
     $class->body[]= new UseExpression(['\\B', '\\C'], $aliases, self::LINE + 1);
 
     $this->assertParsed([$class], 'class A {
@@ -175,7 +175,7 @@ class TypesTest extends ParseTest {
   #[Test]
   public function class_in_namespace() {
     $this->assertParsed(
-      [new NamespaceDeclaration('test', self::LINE), new ClassDeclaration([], '\\test\\A', null, [], [], [], null, self::LINE)],
+      [new NamespaceDeclaration('test', self::LINE), new ClassDeclaration([], '\\test\\A', null, [], [], null, null, self::LINE)],
       'namespace test; class A { }'
     );
   }


### PR DESCRIPTION
This pull request changes the $annotations member from holding associative array to instances of the new lang.ast.nodes.Annotations class. It also adds a bit of consistency:

* Naming now consistenly uses "annotations" everywhere instead of a mix of annotations and attributes
* The lang.ast.nodes.Annotation class is now a Node subclass
* Both classes now carry line numbers

⚠️ This pull request breaks BC and requires changes to the compiler:

```diff
diff --git a/src/main/php/lang/ast/emit/PHP.class.php b/src/main/php/lang/ast/emit/PHP.class.php
index 661fbff..04d5cb9 100755
--- a/src/main/php/lang/ast/emit/PHP.class.php
+++ b/src/main/php/lang/ast/emit/PHP.class.php
@@ -410,6 +410,8 @@ abstract class PHP extends Emitter {

   /** Stores lowercased, unnamespaced name in annotations for BC reasons! */
   protected function annotations($result, $annotations) {
+    if (null === $annotations) return [];
+
     $lookup= [];
     foreach ($annotations as $name => $arguments) {
       $p= strrpos($name, '\\');

```

See also #33