### PR TITLE
Support static closures

### DIFF
--- a/src/main/php/lang/ast/nodes/ClosureExpression.class.php
+++ b/src/main/php/lang/ast/nodes/ClosureExpression.class.php
@@ -4,11 +4,11 @@ class ClosureExpression extends Annotated {
   public $kind= 'closure';
   public $static, $signature, $use, $body;
 
-  public function __construct($static, $signature, $use, $body, $line= -1) {
-    $this->static= $static;
+  public function __construct($signature, $use, $body, $static= false, $line= -1) {
     $this->signature= $signature;
     $this->use= $use;
     $this->body= $body;
+    $this->static= $static;
     $this->line= $line;
   }
 

--- a/src/main/php/lang/ast/nodes/ClosureExpression.class.php
+++ b/src/main/php/lang/ast/nodes/ClosureExpression.class.php
@@ -2,9 +2,10 @@
 
 class ClosureExpression extends Annotated {
   public $kind= 'closure';
-  public $signature, $use, $body;
+  public $static, $signature, $use, $body;
 
-  public function __construct($signature, $use, $body, $line= -1) {
+  public function __construct($static, $signature, $use, $body, $line= -1) {
+    $this->static= $static;
     $this->signature= $signature;
     $this->use= $use;
     $this->body= $body;

--- a/src/main/php/lang/ast/nodes/LambdaExpression.class.php
+++ b/src/main/php/lang/ast/nodes/LambdaExpression.class.php
@@ -2,9 +2,10 @@
 
 class LambdaExpression extends Annotated {
   public $kind= 'lambda';
-  public $signature, $body;
+  public $static, $signature, $body;
 
-  public function __construct($signature, $body, $line= -1) {
+  public function __construct($static, $signature, $body, $line= -1) {
+    $this->static= $static;
     $this->signature= $signature;
     $this->body= $body;
     $this->line= $line;

--- a/src/main/php/lang/ast/nodes/LambdaExpression.class.php
+++ b/src/main/php/lang/ast/nodes/LambdaExpression.class.php
@@ -4,10 +4,10 @@ class LambdaExpression extends Annotated {
   public $kind= 'lambda';
   public $static, $signature, $body;
 
-  public function __construct($static, $signature, $body, $line= -1) {
-    $this->static= $static;
+  public function __construct($signature, $body, $static= false, $line= -1) {
     $this->signature= $signature;
     $this->body= $body;
+    $this->static= $static;
     $this->line= $line;
   }
 

--- a/src/main/php/lang/ast/syntax/PHP.class.php
+++ b/src/main/php/lang/ast/syntax/PHP.class.php
@@ -388,7 +388,7 @@ class PHP extends Language {
       $signature= $this->signature($parse);
       $parse->expecting('=>', 'fn');
 
-      return new LambdaExpression(false, $signature, $this->expression($parse, 0), $token->line);
+      return new LambdaExpression($signature, $this->expression($parse, 0), false, $token->line);
     });
 
     $this->prefix('function', 0, function($parse, $token) {
@@ -421,7 +421,7 @@ class PHP extends Language {
         $parse->forward();
         $signature= $this->signature($parse);
         $parse->expecting('=>', 'fn');
-        return new LambdaExpression(true, $signature, $this->expression($parse, 0), $token->line);
+        return new LambdaExpression($signature, $this->expression($parse, 0), true, $token->line);
       } else {
         return new Literal($token->value, $token->line);
       }
@@ -1439,7 +1439,7 @@ class PHP extends Language {
     $statements= $this->statements($parse);
     $parse->expecting('}', 'function');
 
-    return new ClosureExpression($static, $signature, $use, $statements, $line);
+    return new ClosureExpression($signature, $use, $statements, $static, $line);
   }
 
   public function block($parse) {

--- a/src/test/php/lang/ast/unittest/parse/ClosuresTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/ClosuresTest.class.php
@@ -23,7 +23,7 @@ class ClosuresTest extends ParseTest {
   #[Test]
   public function with_body() {
     $this->assertParsed(
-      [new ClosureExpression(false, new Signature([], null, self::LINE), null, [$this->returns], self::LINE)],
+      [new ClosureExpression(new Signature([], null, self::LINE), null, [$this->returns], false, self::LINE)],
       'function() { return $a + 1; };'
     );
   }
@@ -32,7 +32,7 @@ class ClosuresTest extends ParseTest {
   public function with_param() {
     $params= [new Parameter('a', null, null, false, false, null, null, null, self::LINE)];
     $this->assertParsed(
-      [new ClosureExpression(false, new Signature($params, null, self::LINE), null, [$this->returns], self::LINE)],
+      [new ClosureExpression(new Signature($params, null, self::LINE), null, [$this->returns], false, self::LINE)],
       'function($a) { return $a + 1; };'
     );
   }
@@ -40,7 +40,7 @@ class ClosuresTest extends ParseTest {
   #[Test]
   public function with_use_by_value() {
     $this->assertParsed(
-      [new ClosureExpression(false, new Signature([], null, self::LINE), ['$a', '$b'], [$this->returns], self::LINE)],
+      [new ClosureExpression(new Signature([], null, self::LINE), ['$a', '$b'], [$this->returns], false, self::LINE)],
       'function() use($a, $b) { return $a + 1; };'
     );
   }
@@ -48,7 +48,7 @@ class ClosuresTest extends ParseTest {
   #[Test]
   public function with_use_by_reference() {
     $this->assertParsed(
-      [new ClosureExpression(false, new Signature([], null, self::LINE), ['$a', '&$b'], [$this->returns], self::LINE)],
+      [new ClosureExpression(new Signature([], null, self::LINE), ['$a', '&$b'], [$this->returns], false, self::LINE)],
       'function() use($a, &$b) { return $a + 1; };'
     );
   }
@@ -56,7 +56,7 @@ class ClosuresTest extends ParseTest {
   #[Test]
   public function with_return_type() {
     $this->assertParsed(
-      [new ClosureExpression(false, new Signature([], new Type('int'), self::LINE), null, [$this->returns], self::LINE)],
+      [new ClosureExpression(new Signature([], new Type('int'), self::LINE), null, [$this->returns], false, self::LINE)],
       'function(): int { return $a + 1; };'
     );
   }
@@ -64,7 +64,7 @@ class ClosuresTest extends ParseTest {
   #[Test]
   public function with_nullable_return_type() {
     $this->assertParsed(
-      [new ClosureExpression(false, new Signature([], new Type('?int'), self::LINE), null, [$this->returns], self::LINE)],
+      [new ClosureExpression(new Signature([], new Type('?int'), self::LINE), null, [$this->returns], false, self::LINE)],
       'function(): ?int { return $a + 1; };'
     );
   }
@@ -72,7 +72,7 @@ class ClosuresTest extends ParseTest {
   #[Test]
   public function static_function() {
     $this->assertParsed(
-      [new ClosureExpression(true, new Signature([], null, self::LINE), null, [$this->returns], self::LINE)],
+      [new ClosureExpression(new Signature([], null, self::LINE), null, [$this->returns], true, self::LINE)],
       'static function() { return $a + 1; };'
     );
   }

--- a/src/test/php/lang/ast/unittest/parse/ClosuresTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/ClosuresTest.class.php
@@ -23,7 +23,7 @@ class ClosuresTest extends ParseTest {
   #[Test]
   public function with_body() {
     $this->assertParsed(
-      [new ClosureExpression(new Signature([], null, self::LINE), null, [$this->returns], self::LINE)],
+      [new ClosureExpression(false, new Signature([], null, self::LINE), null, [$this->returns], self::LINE)],
       'function() { return $a + 1; };'
     );
   }
@@ -32,7 +32,7 @@ class ClosuresTest extends ParseTest {
   public function with_param() {
     $params= [new Parameter('a', null, null, false, false, null, null, null, self::LINE)];
     $this->assertParsed(
-      [new ClosureExpression(new Signature($params, null, self::LINE), null, [$this->returns], self::LINE)],
+      [new ClosureExpression(false, new Signature($params, null, self::LINE), null, [$this->returns], self::LINE)],
       'function($a) { return $a + 1; };'
     );
   }
@@ -40,7 +40,7 @@ class ClosuresTest extends ParseTest {
   #[Test]
   public function with_use_by_value() {
     $this->assertParsed(
-      [new ClosureExpression(new Signature([], null, self::LINE), ['$a', '$b'], [$this->returns], self::LINE)],
+      [new ClosureExpression(false, new Signature([], null, self::LINE), ['$a', '$b'], [$this->returns], self::LINE)],
       'function() use($a, $b) { return $a + 1; };'
     );
   }
@@ -48,7 +48,7 @@ class ClosuresTest extends ParseTest {
   #[Test]
   public function with_use_by_reference() {
     $this->assertParsed(
-      [new ClosureExpression(new Signature([], null, self::LINE), ['$a', '&$b'], [$this->returns], self::LINE)],
+      [new ClosureExpression(false, new Signature([], null, self::LINE), ['$a', '&$b'], [$this->returns], self::LINE)],
       'function() use($a, &$b) { return $a + 1; };'
     );
   }
@@ -56,7 +56,7 @@ class ClosuresTest extends ParseTest {
   #[Test]
   public function with_return_type() {
     $this->assertParsed(
-      [new ClosureExpression(new Signature([], new Type('int'), self::LINE), null, [$this->returns], self::LINE)],
+      [new ClosureExpression(false, new Signature([], new Type('int'), self::LINE), null, [$this->returns], self::LINE)],
       'function(): int { return $a + 1; };'
     );
   }
@@ -64,8 +64,16 @@ class ClosuresTest extends ParseTest {
   #[Test]
   public function with_nullable_return_type() {
     $this->assertParsed(
-      [new ClosureExpression(new Signature([], new Type('?int'), self::LINE), null, [$this->returns], self::LINE)],
+      [new ClosureExpression(false, new Signature([], new Type('?int'), self::LINE), null, [$this->returns], self::LINE)],
       'function(): ?int { return $a + 1; };'
+    );
+  }
+
+  #[Test]
+  public function static_function() {
+    $this->assertParsed(
+      [new ClosureExpression(true, new Signature([], null, self::LINE), null, [$this->returns], self::LINE)],
+      'static function() { return $a + 1; };'
     );
   }
 }

--- a/src/test/php/lang/ast/unittest/parse/LambdasTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/LambdasTest.class.php
@@ -15,7 +15,7 @@ class LambdasTest extends ParseTest {
   #[Test]
   public function short_closure() {
     $this->assertParsed(
-      [new LambdaExpression(false, new Signature([$this->parameter], null, self::LINE), $this->expression, self::LINE)],
+      [new LambdaExpression(new Signature([$this->parameter], null, self::LINE), $this->expression, false, self::LINE)],
       'fn($a) => $a + 1;'
     );
   }
@@ -23,7 +23,7 @@ class LambdasTest extends ParseTest {
   #[Test]
   public function static_closure() {
     $this->assertParsed(
-      [new LambdaExpression(true, new Signature([$this->parameter], null, self::LINE), $this->expression, self::LINE)],
+      [new LambdaExpression(new Signature([$this->parameter], null, self::LINE), $this->expression, true, self::LINE)],
       'static fn($a) => $a + 1;'
     );
   }
@@ -33,7 +33,7 @@ class LambdasTest extends ParseTest {
     $this->assertParsed(
       [new InvokeExpression(
         new Literal('execute', self::LINE),
-        [new LambdaExpression(false, new Signature([$this->parameter], null, self::LINE), $this->expression, self::LINE)],
+        [new LambdaExpression(new Signature([$this->parameter], null, self::LINE), $this->expression, false, self::LINE)],
         self::LINE
       )],
       'execute(fn($a) => $a + 1);'
@@ -44,9 +44,9 @@ class LambdasTest extends ParseTest {
   public function short_closure_with_block() {
     $this->assertParsed(
       [new LambdaExpression(
-        false,
         new Signature([$this->parameter], null, self::LINE),
         new Block([new ReturnStatement($this->expression, self::LINE)], self::LINE),
+        false,
         self::LINE
       )],
       'fn($a) => { return $a + 1; };'

--- a/src/test/php/lang/ast/unittest/parse/LambdasTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/LambdasTest.class.php
@@ -15,8 +15,16 @@ class LambdasTest extends ParseTest {
   #[Test]
   public function short_closure() {
     $this->assertParsed(
-      [new LambdaExpression(new Signature([$this->parameter], null, self::LINE), $this->expression, self::LINE)],
+      [new LambdaExpression(false, new Signature([$this->parameter], null, self::LINE), $this->expression, self::LINE)],
       'fn($a) => $a + 1;'
+    );
+  }
+
+  #[Test]
+  public function static_closure() {
+    $this->assertParsed(
+      [new LambdaExpression(true, new Signature([$this->parameter], null, self::LINE), $this->expression, self::LINE)],
+      'static fn($a) => $a + 1;'
     );
   }
 
@@ -25,7 +33,7 @@ class LambdasTest extends ParseTest {
     $this->assertParsed(
       [new InvokeExpression(
         new Literal('execute', self::LINE),
-        [new LambdaExpression(new Signature([$this->parameter], null, self::LINE), $this->expression, self::LINE)],
+        [new LambdaExpression(false, new Signature([$this->parameter], null, self::LINE), $this->expression, self::LINE)],
         self::LINE
       )],
       'execute(fn($a) => $a + 1);'
@@ -36,6 +44,7 @@ class LambdasTest extends ParseTest {
   public function short_closure_with_block() {
     $this->assertParsed(
       [new LambdaExpression(
+        false,
         new Signature([$this->parameter], null, self::LINE),
         new Block([new ReturnStatement($this->expression, self::LINE)], self::LINE),
         self::LINE


### PR DESCRIPTION
These do not bind *$this*:

```php
class T {
  public function closure() {
    return static function() { return isset($this); }; // or: static fn() => isset($this);
  }
}

$closure= (new T())->closure();
var_dump($closure()); // false
```