### PR TITLE
Add support for sealed classes and interfaces

### DIFF
--- a/src/main/php/lang/ast/nodes/ArrayLiteral.class.php
+++ b/src/main/php/lang/ast/nodes/ArrayLiteral.class.php
@@ -5,15 +5,27 @@ use lang\ast\Node;
 /**
  * Array literal - used for both zero-based lists and maps.
  *
- * @test  xp://lang.ast.unittest.nodes.ArrayLiteralTest
+ * @test  lang.ast.unittest.nodes.ArrayLiteralTest
  */
 class ArrayLiteral extends Node {
   public $kind= 'array';
   public $values;
 
-  public function __construct($values, $line= -1) {
+  public function __construct($values= [], $line= -1) {
     $this->values= $values;
     $this->line= $line;
+  }
+
+  /** Appends a given key value pair to a map */
+  public function add(Node $key, Node $value): self {
+    $this->values[]= [$key, $value];
+    return $this;
+  }
+
+  /** Appends a given node to a zero-based list */
+  public function append(Node $value): self {
+    $this->values[]= [null, $value];
+    return $this;
   }
 
   /** @return iterable */

--- a/src/main/php/lang/ast/nodes/ClassDeclaration.class.php
+++ b/src/main/php/lang/ast/nodes/ClassDeclaration.class.php
@@ -3,6 +3,7 @@
 class ClassDeclaration extends TypeDeclaration {
   public $kind= 'class';
   public $parent, $implements;
+  public $permits= [];
 
   public function __construct(
     $modifiers,

--- a/src/main/php/lang/ast/nodes/InterfaceDeclaration.class.php
+++ b/src/main/php/lang/ast/nodes/InterfaceDeclaration.class.php
@@ -3,6 +3,7 @@
 class InterfaceDeclaration extends TypeDeclaration {
   public $kind= 'interface';
   public $parents;
+  public $permits= [];
 
   public function __construct(
     $modifiers,

--- a/src/main/php/lang/ast/syntax/PHP.class.php
+++ b/src/main/php/lang/ast/syntax/PHP.class.php
@@ -875,7 +875,7 @@ class PHP extends Language {
           $parse->forward();
           if (',' === $parse->token->value) {
             $parse->forward();
-          } else if ('{' === $parse->token->value) {
+          } else if ('{' === $parse->token->value || 'permits' === $parse->token->value) {
             break;
           } else {
             $parse->expecting(', or {', 'interface parents');
@@ -883,9 +883,26 @@ class PHP extends Language {
         } while (true);
       }
 
+      $permits= [];
+      if ('permits' === $parse->token->value) {
+        $parse->forward();
+        do {
+          $permits[]= $parse->scope->resolve($parse->token->value);
+          $parse->forward();
+          if (',' === $parse->token->value) {
+            $parse->forward();
+          } else if ('{' === $parse->token->value) {
+            break;
+          } else {
+            $parse->expecting(', or {', 'permits list');
+          }
+        } while (true);
+      }
+
       $decl= new InterfaceDeclaration([], $name, $parents, [], null, $comment, $token->line);
       $parse->expecting('{', 'interface');
       $decl->body= $this->typeBody($parse, $decl->name);
+      $decl->permits= $permits;
       $parse->expecting('}', 'interface');
 
       return $decl;
@@ -1470,7 +1487,7 @@ class PHP extends Language {
         $parse->forward();
         if (',' === $parse->token->value) {
           $parse->forward();
-        } else if ('{' === $parse->token->value) {
+        } else if ('{' === $parse->token->value || 'permits' === $parse->token->value) {
           break;
         } else {
           $parse->expecting(', or {', 'interfaces list');
@@ -1478,9 +1495,26 @@ class PHP extends Language {
       } while (true);
     }
 
+    $permits= [];
+    if ('permits' === $parse->token->value) {
+      $parse->forward();
+      do {
+        $permits[]= $parse->scope->resolve($parse->token->value);
+        $parse->forward();
+        if (',' === $parse->token->value) {
+          $parse->forward();
+        } else if ('{' === $parse->token->value) {
+          break;
+        } else {
+          $parse->expecting(', or {', 'permits list');
+        }
+      } while (true);
+    }
+
     $decl= new ClassDeclaration($modifiers, $name, $parent, $implements, [], null, $comment, $line);
     $parse->expecting('{', 'class');
     $decl->body= $this->typeBody($parse, $decl->name);
+    $decl->permits= $permits;
     $parse->expecting('}', 'class');
 
     return $decl;

--- a/src/test/php/lang/ast/unittest/nodes/ArrayLiteralTest.class.php
+++ b/src/test/php/lang/ast/unittest/nodes/ArrayLiteralTest.class.php
@@ -7,7 +7,7 @@ class ArrayLiteralTest extends NodeTest {
 
   #[Test]
   public function can_create() {
-    new ArrayLiteral([]);
+    new ArrayLiteral();
   }
 
   #[Test]
@@ -37,5 +37,21 @@ class ArrayLiteralTest extends NodeTest {
   public function map_children() {
     $values= [[new Literal('"one"'), new Literal(1)]];
     Assert::equals([new Literal('"one"'), new Literal(1)], $this->childrenOf(new ArrayLiteral($values)));
+  }
+
+  #[Test]
+  public function append() {
+    Assert::equals(
+      [[null, new Literal(1)]],
+      (new ArrayLiteral())->append(new Literal(1))->values
+    );
+  }
+
+  #[Test]
+  public function add() {
+    Assert::equals(
+      [[new Literal('"one"'), new Literal(1)]],
+      (new ArrayLiteral())->add(new Literal('"one"'), new Literal(1))->values
+    );
   }
 }


### PR DESCRIPTION
Based on https://wiki.php.net/rfc/sealed_classes

```php
abstract class Throwable permits Exception, Error {
  // ...
}
```

See also xp-framework/core#308