### PR TITLE
Handle short closures with blocks vs. single-expression form

### DIFF
--- a/src/test/php/lang/ast/unittest/parse/LambdasTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/LambdasTest.class.php
@@ -49,6 +49,20 @@ class LambdasTest extends ParseTest {
         false,
         self::LINE
       )],
+      'fn($a) { return $a + 1; };'
+    );
+  }
+
+  /** @deprecated */
+  #[Test]
+  public function short_closure_with_block_and_arrow() {
+    $this->assertParsed(
+      [new LambdaExpression(
+        new Signature([$this->parameter], null, self::LINE),
+        new Block([new ReturnStatement($this->expression, self::LINE)], self::LINE),
+        false,
+        self::LINE
+      )],
       'fn($a) => { return $a + 1; };'
     );
   }


### PR DESCRIPTION
This PR implements an extension of the Arrow Function syntax supporting multiple statements proposed by https://wiki.php.net/rfc/auto-capture-closure.

## Example

```php
$key= new Secret('...');

// Single expression form
$encrypt= fn($value, $nonce) => sodium_crypto_secretbox($value, $nonce, $key->reveal());

// Short closure with block
$decrypt= fn($cipher, $nonce) {
  if (false === ($r= sodium_crypto_secretbox_open($cipher, $nonce, $key->reveal()))) {
    throw new FormatException('Decryption failed');
  }
  return $r;
};
```

## Diff for XP Compiler

No additional changes are required except for a couple of integration tests.

### See also

* https://github.com/php/php-src/pull/8330
* https://github.com/php/php-src/pull/6246#discussion_r498381881