### PR TITLE
Refactor type declaration, parents, interfaces to lang.ast.Type instances

### DIFF
--- a/src/main/php/lang/ast/ParseTree.class.php
+++ b/src/main/php/lang/ast/ParseTree.class.php
@@ -52,7 +52,7 @@ class ParseTree implements Value {
    */
   public function types() {
     foreach ($this->children as $node) {
-      if ($node->is('@type')) yield $this->scope->resolve($node->name) => $node;
+      if ($node->is('@type')) yield $this->scope->resolve($node->name->literal()) => $node;
     }
   }
 

--- a/src/main/php/lang/ast/Type.class.php
+++ b/src/main/php/lang/ast/Type.class.php
@@ -5,7 +5,7 @@ use lang\Value;
 /**
  * Represents a type
  *
- * @test  xp://lang.ast.unittest.TypeTest
+ * @test  lang.ast.unittest.TypeTest
  */
 class Type implements Value {
   public $literal;
@@ -24,6 +24,9 @@ class Type implements Value {
     isset($map[$name]) && $name= $map[$name];
     return '?' === $this->literal[0] ? '?'.$name : $name;
   }
+
+  /** @return string */
+  public function __toString() { return $this->literal; }
 
   /** @return string */
   public function toString() { return nameof($this).'('.$this->name().')'; }

--- a/src/main/php/lang/ast/nodes/TypeDeclaration.class.php
+++ b/src/main/php/lang/ast/nodes/TypeDeclaration.class.php
@@ -1,5 +1,7 @@
 <?php namespace lang\ast\nodes;
 
+use lang\ast\Type;
+
 abstract class TypeDeclaration extends Annotated {
   public $modifiers, $name, $body;
 
@@ -34,7 +36,7 @@ abstract class TypeDeclaration extends Annotated {
    * @return string
    */
   public function name() {
-    return substr($this->name, 1);
+    return substr($this->name->literal(), 1);
   }
 
   /**
@@ -43,7 +45,8 @@ abstract class TypeDeclaration extends Annotated {
    * @return string
    */
   public function declaration() {
-    return substr($this->name, strrpos($this->name, '\\') + 1);
+    $literal= $this->name->literal();
+    return substr($literal, strrpos($literal, '\\') + 1);
   }
 
   public function parent() { return null; }

--- a/src/main/php/lang/ast/syntax/PHP.class.php
+++ b/src/main/php/lang/ast/syntax/PHP.class.php
@@ -62,7 +62,18 @@ use lang\ast\nodes\{
   YieldExpression,
   YieldFromExpression
 };
-use lang\ast\types\{IsArray, IsFunction, IsMap, IsUnion, IsIntersection, IsValue, IsNullable, IsGeneric, IsLiteral};
+use lang\ast\types\{
+  IsArray,
+  IsExpression,
+  IsFunction,
+  IsGeneric,
+  IsIntersection,
+  IsLiteral,
+  IsMap,
+  IsNullable,
+  IsUnion,
+  IsValue
+};
 use lang\ast\{Token, Language, Error};
 
 /**
@@ -305,10 +316,10 @@ class PHP extends Language {
     $this->prefix('new', 0, function($parse, $token) {
       if ('(' === $parse->token->value) {
         $parse->expecting('(', 'new type');
-        $type= $this->expression($parse, 0);
+        $type= new IsExpression($this->expression($parse, 0));
         $parse->expecting(')', 'new type');
       } else if ('variable' === $parse->token->kind) {
-        $type= $parse->token->value;
+        $type= new IsExpression(new Variable(substr($parse->token->value, 1)));
         $parse->forward();
       } else if ('class' === $parse->token->value) {
         $annotations= null;
@@ -320,8 +331,7 @@ class PHP extends Language {
         $parse->expecting('class', 'anonymous class annotations');
         $type= null;
       } else {
-        $type= $parse->scope->resolve($parse->token->value);
-        $parse->forward();
+        $type= $this->type($parse, false);
       }
 
       $parse->expecting('(', 'new arguments');
@@ -859,9 +869,7 @@ class PHP extends Language {
     $this->stmt('class', function($parse, $token) {
       $comment= $parse->comment;
       $parse->comment= null;
-
-      $name= $parse->scope->resolve($parse->token->value);
-      $parse->forward();
+      $name= $this->type($parse, false);
 
       return $this->class($parse, $name, $comment);
     });
@@ -869,16 +877,13 @@ class PHP extends Language {
     $this->stmt('interface', function($parse, $token) {
       $comment= $parse->comment;
       $parse->comment= null;
-
-      $name= $parse->scope->resolve($parse->token->value);
-      $parse->forward();
+      $name= $this->type($parse, false);
 
       $parents= [];
       if ('extends' === $parse->token->value) {
         $parse->forward();
         do {
-          $parents[]= $parse->scope->resolve($parse->token->value);
-          $parse->forward();
+          $parents[]= $this->type($parse, false);
           if (',' === $parse->token->value) {
             $parse->forward();
           } else if ('{' === $parse->token->value) {
@@ -900,9 +905,7 @@ class PHP extends Language {
     $this->stmt('trait', function($parse, $token) {
       $comment= $parse->comment;
       $parse->comment= null;
-
-      $name= $parse->scope->resolve($parse->token->value);
-      $parse->forward();
+      $name= $this->type($parse, false);
 
       $decl= new TraitDeclaration([], $name, [], null, $comment, $token->line);
       $parse->expecting('{', 'trait');
@@ -915,16 +918,13 @@ class PHP extends Language {
     $this->stmt('enum', function($parse, $token) {
       $comment= $parse->comment;
       $parse->comment= null;
-
-      $name= $parse->scope->resolve($parse->token->value);
-      $parse->forward();
+      $name= $this->type($parse, false);
 
       $implements= [];
       if ('implements' === $parse->token->value) {
         $parse->forward();
         do {
-          $implements[]= $parse->scope->resolve($parse->token->value);
-          $parse->forward();
+          $implements[]= $this->type($parse, false);
           if (',' === $parse->token->value) {
             $parse->forward();
             continue;
@@ -1467,16 +1467,14 @@ class PHP extends Language {
     $parent= null;
     if ('extends' === $parse->token->value) {
       $parse->forward();
-      $parent= $parse->scope->resolve($parse->token->value);
-      $parse->forward();
+      $parent= $this->type($parse, false);
     }
 
     $implements= [];
     if ('implements' === $parse->token->value) {
       $parse->forward();
       do {
-        $implements[]= $parse->scope->resolve($parse->token->value);
-        $parse->forward();
+        $implements[]= $this->type($parse, false);
         if (',' === $parse->token->value) {
           $parse->forward();
         } else if ('{' === $parse->token->value) {

--- a/src/main/php/lang/ast/syntax/PHP.class.php
+++ b/src/main/php/lang/ast/syntax/PHP.class.php
@@ -1227,7 +1227,7 @@ class PHP extends Language {
       if ('array' === $type) {
         return 1 === sizeof($components) ? new IsArray($components[0]) : new IsMap($components[0], $components[1]);
       } else {
-        return new IsGeneric($type, $components);
+        return new IsGeneric(new IsValue($type), $components);
       }
     }
 

--- a/src/main/php/lang/ast/types/IsExpression.class.php
+++ b/src/main/php/lang/ast/types/IsExpression.class.php
@@ -1,0 +1,44 @@
+<?php namespace lang\ast\types;
+
+use lang\IllegalStateException;
+use lang\ast\Type;
+use util\Objects;
+
+class IsExpression extends Type {
+  public $expression;
+
+  /**
+   * Creates a new type
+   *
+   * @param  lang.ast.Node $expression
+   */
+  public function __construct($expression) {
+    $this->expression= $expression;
+  }
+
+  /** @return string */
+  public function name() {
+    throw new IllegalStateException('Expressions cannot be used as type name');
+  }
+
+  /** @return string */
+  public function literal() {
+    throw new IllegalStateException('Expressions cannot be used as type literal');
+  }
+
+  /** @return string */
+  public function toString() { return nameof($this).'({'.nameof($this->expression).'})'; }
+
+  /** @return string */
+  public function hashCode() { return '{'.spl_object_hash($this->expression); }
+
+  /**
+   * Compare
+   *
+   * @param  var $value
+   * @return int
+   */
+  public function compareTo($value) {
+    return $value instanceof static ? Objects::compare($this->expression, $value->expression) : 1;
+  }
+}

--- a/src/main/php/lang/ast/types/IsGeneric.class.php
+++ b/src/main/php/lang/ast/types/IsGeneric.class.php
@@ -8,7 +8,7 @@ class IsGeneric extends Type {
   /**
    * Creates a new type
    *
-   * @param  string $base
+   * @param  parent $base
    * @param  parent[] $components
    */
   public function __construct($base, $components= []) {

--- a/src/test/php/lang/ast/unittest/AnnotationsTest.class.php
+++ b/src/test/php/lang/ast/unittest/AnnotationsTest.class.php
@@ -1,6 +1,7 @@
 <?php namespace lang\ast\unittest;
 
 use lang\ast\nodes\{Annotation, Annotations, ClassDeclaration};
+use lang\ast\types\IsValue;
 use unittest\{Assert, Before, Test, Values};
 
 class AnnotationsTest {
@@ -94,25 +95,25 @@ class AnnotationsTest {
 
   #[Test]
   public function no_annotations_from_declaration() {
-    Assert::equals([], (new ClassDeclaration([], 'Test', null, [], [], null))->annotations());
+    Assert::equals([], (new ClassDeclaration([], new IsValue('T'), null, [], [], null))->annotations());
   }
 
   #[Test]
   public function no_annotation_from_declaration() {
-    Assert::null((new ClassDeclaration([], 'Test', null, [], [], null))->annotation(Test::class));
+    Assert::null((new ClassDeclaration([], new IsValue('T'), null, [], [], null))->annotation(Test::class));
   }
 
   #[Test]
   public function annotation_from_declaration() {
     Assert::equals(
       $this->annotation,
-      (new ClassDeclaration([], 'Test', null, [], [], new Annotations([Test::class => []])))->annotation(Test::class)
+      (new ClassDeclaration([], new IsValue('T'), null, [], [], new Annotations([Test::class => []])))->annotation(Test::class)
     );
   }
 
   #[Test]
   public function annotate_declaration() {
-    $declaration= new ClassDeclaration([], 'Test', null, [], [], new Annotations([Test::class => []]));
+    $declaration= new ClassDeclaration([], new IsValue('T'), null, [], [], new Annotations([Test::class => []]));
     Assert::equals(
       [Test::class => $this->annotation, Values::class => new Annotation(Values::class, [])],
       $declaration->annotate(new Annotation(Values::class, []))->annotations()
@@ -121,7 +122,7 @@ class AnnotationsTest {
 
   #[Test]
   public function annotate_declaration_without_annotations() {
-    $declaration= new ClassDeclaration([], 'Test', null, [], [], null);
+    $declaration= new ClassDeclaration([], new IsValue('T'), null, [], [], null);
     Assert::equals(
       [Test::class => $this->annotation],
       $declaration->annotate($this->annotation)->annotations()
@@ -130,7 +131,7 @@ class AnnotationsTest {
 
   #[Test]
   public function set_declarations_annotations() {
-    $declaration= new ClassDeclaration([], 'Test', null, [], [], null);
+    $declaration= new ClassDeclaration([], new IsValue('T'), null, [], [], null);
     Assert::equals(
       [Test::class => $this->annotation],
       $declaration->annotate(new Annotations([Test::class => []]))->annotations()

--- a/src/test/php/lang/ast/unittest/ClassTest.class.php
+++ b/src/test/php/lang/ast/unittest/ClassTest.class.php
@@ -1,6 +1,7 @@
 <?php namespace lang\ast\unittest;
 
 use lang\ast\nodes\{ClassDeclaration, Method, Signature};
+use lang\ast\types\IsValue;
 use unittest\{Assert, Before, Test};
 
 class ClassTest {
@@ -13,7 +14,7 @@ class ClassTest {
 
   #[Test]
   public function method() {
-    $fixture= new ClassDeclaration([], 'Test', null, [], [], null);
+    $fixture= new ClassDeclaration([], new IsValue('T'), null, [], [], null);
     $fixture->declare($this->method);
 
     Assert::equals($this->method, $fixture->method('toString'));
@@ -21,7 +22,7 @@ class ClassTest {
 
   #[Test]
   public function methods() {
-    $fixture= new ClassDeclaration([], 'Test', null, [], [], null);
+    $fixture= new ClassDeclaration([], new IsValue('T'), null, [], [], null);
     $fixture->declare($this->method);
     
     Assert::equals(['toString' => $this->method], iterator_to_array($fixture->methods()));
@@ -31,7 +32,7 @@ class ClassTest {
   public function overwrite() {
     $overwritten= new Method([], 'toString', new Signature([], null), [], null, 'Overwritten');
 
-    $fixture= new ClassDeclaration([], 'Test', null, [], [], null);
+    $fixture= new ClassDeclaration([], new IsValue('T'), null, [], [], null);
     $fixture->declare($this->method);
     $fixture->overwrite($overwritten);
 
@@ -42,7 +43,7 @@ class ClassTest {
   public function declare() {
     $overwritten= new Method([], 'toString', new Signature([], null), [], null, 'Overwritten');
 
-    $fixture= new ClassDeclaration([], 'Test', null, [], [], null);
+    $fixture= new ClassDeclaration([], new IsValue('T'), null, [], [], null);
     $fixture->declare($this->method);
     $fixture->declare($overwritten);
 

--- a/src/test/php/lang/ast/unittest/ParseTreeTest.class.php
+++ b/src/test/php/lang/ast/unittest/ParseTreeTest.class.php
@@ -1,7 +1,7 @@
 <?php namespace lang\ast\unittest;
 
 use lang\ast\nodes\{ClassDeclaration, NamespaceDeclaration};
-use lang\ast\types\{Compiled, Reflection};
+use lang\ast\types\{Compiled, Reflection, IsValue};
 use lang\ast\{ParseTree, Scope};
 use unittest\{Assert, Test, Values};
 
@@ -55,7 +55,7 @@ class ParseTreeTest {
   public function types_in($package, $expected) {
     $scope= new Scope(null);
     $scope->package($package);
-    $class= new ClassDeclaration([], 'Test');
+    $class= new ClassDeclaration([], new IsValue('Test'));
 
     Assert::equals([$expected => $class], iterator_to_array((new ParseTree([$class], $scope))->types()));
   }

--- a/src/test/php/lang/ast/unittest/TypeTest.class.php
+++ b/src/test/php/lang/ast/unittest/TypeTest.class.php
@@ -44,12 +44,26 @@ class TypeTest {
 
   #[Test, Values(['int', 'string'])]
   public function generic_list($t) {
-    Assert::equals(new IsGeneric('List', [new IsLiteral($t)]), $this->parse('List<'.$t.'>'));
+    Assert::equals(
+      new IsGeneric(new IsValue('List'), [new IsLiteral($t)]),
+      $this->parse('List<'.$t.'>')
+    );
   }
 
   #[Test, Values(['int', 'string'])]
   public function generic_map($t) {
-    Assert::equals(new IsGeneric('Map', [new IsLiteral('string'), new IsLiteral($t)]), $this->parse('Map<string, '.$t.'>'));
+    Assert::equals(
+      new IsGeneric(new IsValue('Map'), [new IsLiteral('string'), new IsLiteral($t)]),
+      $this->parse('Map<string, '.$t.'>')
+    );
+  }
+
+  #[Test]
+  public function nested_generic() {
+    Assert::equals(
+      new IsGeneric(new IsValue('Filter'), [new IsGeneric(new IsValue('Set'), [new IsLiteral('T')])]),
+      $this->parse('Filter<Set<T>>')
+    );
   }
 
   #[Test, Values(['self', 'static', 'parent', 'Value', '\\lang\\Value',])]

--- a/src/test/php/lang/ast/unittest/parse/CommentTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/CommentTest.class.php
@@ -1,6 +1,7 @@
 <?php namespace lang\ast\unittest\parse;
 
 use lang\ast\nodes\{Annotations, ClassDeclaration, Comment, Constant, Property, Method, Signature, Literal};
+use lang\ast\types\IsValue;
 use unittest\{Assert, Test};
 
 class CommentTest extends ParseTest {
@@ -94,14 +95,14 @@ class CommentTest extends ParseTest {
 
   #[Test]
   public function apidoc_comment_after_class_name_discarded() {
-    $this->assertParsed([new ClassDeclaration([], '\\T', null, [], [], null, null, 2)], '
+    $this->assertParsed([new ClassDeclaration([], new IsValue('\\T'), null, [], [], null, null, 2)], '
       class T /** Discarded */ { }
     ');
   }
 
   #[Test]
   public function apidoc_comment_attached_to_next_node() {
-    $this->assertParsed([new ClassDeclaration([], '\\T', null, [], [], null, new Comment('/** @api */', 2), 3)], '
+    $this->assertParsed([new ClassDeclaration([], new IsValue('\\T'), null, [], [], null, new Comment('/** @api */', 2), 3)], '
       /** @api */
       class T { }
     ');
@@ -109,7 +110,7 @@ class CommentTest extends ParseTest {
 
   #[Test]
   public function apidoc_comment_and_annotations() {
-    $this->assertParsed([new ClassDeclaration([], '\\T', null, [], [], new Annotations(['Test' => []], 3), new Comment('/** @api */', 2), 4)], '
+    $this->assertParsed([new ClassDeclaration([], new IsValue('\\T'), null, [], [], new Annotations(['Test' => []], 3), new Comment('/** @api */', 2), 4)], '
       /** @api */
       #[Test]
       class T { }
@@ -118,7 +119,7 @@ class CommentTest extends ParseTest {
 
   #[Test]
   public function apidoc_comment_attached_to_next_constant() {
-    $class= new ClassDeclaration([], '\\T', null, [], [], null, null, 2);
+    $class= new ClassDeclaration([], new IsValue('\\T'), null, [], [], null, null, 2);
     $class->declare(new Constant(['public'], 'FIXTURE', null, new Literal('1', 4), null, new Comment('/** @api */', 3), 4));
 
     $this->assertParsed([$class], '
@@ -131,7 +132,7 @@ class CommentTest extends ParseTest {
 
   #[Test]
   public function apidoc_comment_attached_to_next_property() {
-    $class= new ClassDeclaration([], '\\T', null, [], [], null, null, 2);
+    $class= new ClassDeclaration([], new IsValue('\\T'), null, [], [], null, null, 2);
     $class->declare(new Property(['public'], 'fixture', null, null, null, new Comment('/** @api */', 3), 4));
 
     $this->assertParsed([$class], '
@@ -144,7 +145,7 @@ class CommentTest extends ParseTest {
 
   #[Test]
   public function apidoc_comment_attached_to_next_method() {
-    $class= new ClassDeclaration([], '\\T', null, [], [], null, null, 2);
+    $class= new ClassDeclaration([], new IsValue('\\T'), null, [], [], null, null, 2);
     $class->declare(new Method(['public'], '__construct', new Signature([], null, 4), [], null, new Comment('/** @api */', 3), 4));
 
     $this->assertParsed([$class], '

--- a/src/test/php/lang/ast/unittest/parse/InvokeTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/InvokeTest.class.php
@@ -11,6 +11,7 @@ use lang\ast\nodes\{
   Literal,
   Variable
 };
+use lang\ast\types\IsValue;
 use unittest\{Assert, Test};
 
 /**
@@ -101,7 +102,7 @@ class InvokeTest extends ParseTest {
   #[Test]
   public function first_class_callable_object_creation() {
     $this->assertParsed(
-      [new CallableNewExpression(new NewExpression('\\T', null, self::LINE), self::LINE)],
+      [new CallableNewExpression(new NewExpression(new IsValue('\\T'), null, self::LINE), self::LINE)],
       'new T(...);'
     );
   }

--- a/src/test/php/lang/ast/unittest/parse/MatchExpressionTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/MatchExpressionTest.class.php
@@ -1,6 +1,16 @@
 <?php namespace lang\ast\unittest\parse;
 
-use lang\ast\nodes\{MatchExpression, MatchCondition, Literal, Variable, Block, ReturnStatement, ThrowExpression, NewExpression};
+use lang\ast\nodes\{
+  MatchExpression,
+  MatchCondition,
+  Literal,
+  Variable,
+  Block,
+  ReturnStatement,
+  ThrowExpression,
+  NewExpression
+};
+use lang\ast\types\IsValue;
 use unittest\{Assert, Test};
 
 class MatchExpressionTest extends ParseTest {
@@ -36,7 +46,7 @@ class MatchExpressionTest extends ParseTest {
 
   #[Test]
   public function match_with_throw_expression() {
-    $default= new ThrowExpression(new NewExpression('\Exception', [], self::LINE), self::LINE);
+    $default= new ThrowExpression(new NewExpression(new IsValue('\Exception'), [], self::LINE), self::LINE);
     $this->assertParsed(
       [new MatchExpression(new Variable('arg', self::LINE), [], $default, self::LINE)],
       'match ($arg) { default => throw new Exception() };'

--- a/src/test/php/lang/ast/unittest/parse/MembersTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/MembersTest.class.php
@@ -36,7 +36,7 @@ class MembersTest extends ParseTest {
 
   #[Test]
   public function private_instance_property() {
-    $class= new ClassDeclaration([], '\\A', null, [], [], null, null, self::LINE);
+    $class= new ClassDeclaration([], new IsValue('\\A'), null, [], [], null, null, self::LINE);
     $class->declare(new Property(['private'], 'a', null, null, null, null, self::LINE));
 
     $this->assertParsed([$class], 'class A { private $a; }');
@@ -44,7 +44,7 @@ class MembersTest extends ParseTest {
 
   #[Test]
   public function private_instance_properties() {
-    $class= new ClassDeclaration([], '\\A', null, [], [], null, null, self::LINE);
+    $class= new ClassDeclaration([], new IsValue('\\A'), null, [], [], null, null, self::LINE);
     $class->declare(new Property(['private'], 'a', null, null, null, null, self::LINE));
     $class->declare(new Property(['private'], 'b', null, null, null, null, self::LINE));
 
@@ -53,7 +53,7 @@ class MembersTest extends ParseTest {
 
   #[Test]
   public function private_instance_method() {
-    $class= new ClassDeclaration([], '\\A', null, [], [], null, null, self::LINE);
+    $class= new ClassDeclaration([], new IsValue('\\A'), null, [], [], null, null, self::LINE);
     $class->declare(new Method(['private'], 'a', new Signature([], null, self::LINE), [], null, null, self::LINE));
 
     $this->assertParsed([$class], 'class A { private function a() { } }');
@@ -61,7 +61,7 @@ class MembersTest extends ParseTest {
 
   #[Test]
   public function private_static_method() {
-    $class= new ClassDeclaration([], '\\A', null, [], [], null, null, self::LINE);
+    $class= new ClassDeclaration([], new IsValue('\\A'), null, [], [], null, null, self::LINE);
     $class->declare(new Method(['private', 'static'], 'a', new Signature([], null, self::LINE), [], null, null, self::LINE));
 
     $this->assertParsed([$class], 'class A { private static function a() { } }');
@@ -69,7 +69,7 @@ class MembersTest extends ParseTest {
 
   #[Test]
   public function class_constant() {
-    $class= new ClassDeclaration([], '\\A', null, [], [], null, null, self::LINE);
+    $class= new ClassDeclaration([], new IsValue('\\A'), null, [], [], null, null, self::LINE);
     $class->declare(new Constant([], 'T', null, new Literal('1', self::LINE), null, null, self::LINE));
 
     $this->assertParsed([$class], 'class A { const T = 1; }');
@@ -77,7 +77,7 @@ class MembersTest extends ParseTest {
 
   #[Test]
   public function class_constants() {
-    $class= new ClassDeclaration([], '\\A', null, [], [], null, null, self::LINE);
+    $class= new ClassDeclaration([], new IsValue('\\A'), null, [], [], null, null, self::LINE);
     $class->declare(new Constant([], 'T', null, new Literal('1', self::LINE), null, null, self::LINE));
     $class->declare(new Constant([], 'S', null, new Literal('2', self::LINE), null, null, self::LINE));
 
@@ -86,7 +86,7 @@ class MembersTest extends ParseTest {
 
   #[Test]
   public function private_class_constant() {
-    $class= new ClassDeclaration([], '\\A', null, [], [], null, null, self::LINE);
+    $class= new ClassDeclaration([], new IsValue('\\A'), null, [], [], null, null, self::LINE);
     $class->declare(new Constant(['private'], 'T', null, new Literal('1', self::LINE), null, null, self::LINE));
 
     $this->assertParsed([$class], 'class A { private const T = 1; }');
@@ -94,7 +94,7 @@ class MembersTest extends ParseTest {
 
   #[Test, Values('types')]
   public function method_with_typed_parameter($declaration, $expected) {
-    $class= new ClassDeclaration([], '\\A', null, [], [], null, null, self::LINE);
+    $class= new ClassDeclaration([], new IsValue('\\A'), null, [], [], null, null, self::LINE);
     $params= [new Parameter('param', $expected, null, false, false, null, null, null, self::LINE)];
     $class->declare(new Method(['public'], 'a', new Signature($params, null, self::LINE), [], null, null, self::LINE));
 
@@ -103,7 +103,7 @@ class MembersTest extends ParseTest {
 
   #[Test, Values('types')]
   public function method_with_return_type($declaration, $expected) {
-    $class= new ClassDeclaration([], '\\A', null, [], [], null, null, self::LINE);
+    $class= new ClassDeclaration([], new IsValue('\\A'), null, [], [], null, null, self::LINE);
     $class->declare(new Method(['public'], 'a', new Signature([], $expected, self::LINE), [], null, null, self::LINE));
 
     $this->assertParsed([$class], 'class A { public function a(): '.$declaration.' { } }');
@@ -112,7 +112,7 @@ class MembersTest extends ParseTest {
   #[Test]
   public function method_with_annotation() {
     $annotations= new Annotations(['Test' => []], self::LINE);
-    $class= new ClassDeclaration([], '\\A', null, [], [], null, null, self::LINE);
+    $class= new ClassDeclaration([], new IsValue('\\A'), null, [], [], null, null, self::LINE);
     $class->declare(new Method(['public'], 'a', new Signature([], null, self::LINE), [], $annotations, null, self::LINE));
 
     $this->assertParsed([$class], 'class A { #[Test] public function a() { } }');
@@ -121,7 +121,7 @@ class MembersTest extends ParseTest {
   #[Test]
   public function method_with_annotations() {
     $annotations= new Annotations(['Test' => [], 'Ignore' => [new Literal('"Not implemented"', self::LINE)]], self::LINE);
-    $class= new ClassDeclaration([], '\\A', null, [], [], null, null, self::LINE);
+    $class= new ClassDeclaration([], new IsValue('\\A'), null, [], [], null, null, self::LINE);
     $class->declare(new Method(['public'], 'a', new Signature([], null, self::LINE), [], $annotations, null, self::LINE));
 
     $this->assertParsed([$class], 'class A { #[Test, Ignore("Not implemented")] public function a() { } }');
@@ -214,7 +214,7 @@ class MembersTest extends ParseTest {
 
   #[Test]
   public function typed_property() {
-    $class= new ClassDeclaration([], '\\A', null, [], [], null, null, self::LINE);
+    $class= new ClassDeclaration([], new IsValue('\\A'), null, [], [], null, null, self::LINE);
     $class->declare(new Property(['private'], 'a', new Type('string'), null, null, null, self::LINE));
 
     $this->assertParsed([$class], 'class A { private string $a; }');
@@ -222,7 +222,7 @@ class MembersTest extends ParseTest {
 
   #[Test]
   public function typed_property_with_value() {
-    $class= new ClassDeclaration([], '\\A', null, [], [], null, null, self::LINE);
+    $class= new ClassDeclaration([], new IsValue('\\A'), null, [], [], null, null, self::LINE);
     $class->declare(new Property(['private'], 'a', new Type('string'), new Literal('"test"', self::LINE), null, null, self::LINE));
 
     $this->assertParsed([$class], 'class A { private string $a = "test"; }');
@@ -230,7 +230,7 @@ class MembersTest extends ParseTest {
 
   #[Test]
   public function typed_properties() {
-    $class= new ClassDeclaration([], '\\A', null, [], [], null, null, self::LINE);
+    $class= new ClassDeclaration([], new IsValue('\\A'), null, [], [], null, null, self::LINE);
     $class->declare(new Property(['private'], 'a', new Type('string'), null, null, null, self::LINE));
     $class->declare(new Property(['private'], 'b', new Type('string'), null, null, null, self::LINE));
     $class->declare(new Property(['private'], 'c', new Type('int'), null, null, null, self::LINE));
@@ -240,7 +240,7 @@ class MembersTest extends ParseTest {
 
   #[Test]
   public function readonly_property() {
-    $class= new ClassDeclaration([], '\\A', null, [], [], null, null, self::LINE);
+    $class= new ClassDeclaration([], new IsValue('\\A'), null, [], [], null, null, self::LINE);
     $class->declare(new Property(['public', 'readonly'], 'a', new Type('int'), null, null, null, self::LINE));
 
     $this->assertParsed([$class], 'class A { public readonly int $a; }');
@@ -248,7 +248,7 @@ class MembersTest extends ParseTest {
 
   #[Test]
   public function typed_constant() {
-    $class= new ClassDeclaration([], '\\A', null, [], [], null, null, self::LINE);
+    $class= new ClassDeclaration([], new IsValue('\\A'), null, [], [], null, null, self::LINE);
     $class->declare(new Constant([], 'T', new Type('int'), new Literal('1', self::LINE), null, null, self::LINE));
 
     $this->assertParsed([$class], 'class A { const int T = 1; }');
@@ -256,7 +256,7 @@ class MembersTest extends ParseTest {
 
   #[Test]
   public function typed_constants() {
-    $class= new ClassDeclaration([], '\\A', null, [], [], null, null, self::LINE);
+    $class= new ClassDeclaration([], new IsValue('\\A'), null, [], [], null, null, self::LINE);
     $class->declare(new Constant([], 'T', new Type('int'), new Literal('1', self::LINE), null, null, self::LINE));
     $class->declare(new Constant([], 'S', new Type('int'), new Literal('2', self::LINE), null, null, self::LINE));
     $class->declare(new Constant([], 'I', new Type('string'), new Literal('"i"', self::LINE), null, null, self::LINE));

--- a/src/test/php/lang/ast/unittest/parse/OperatorTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/OperatorTest.class.php
@@ -18,6 +18,7 @@ use lang\ast\nodes\{
   UnaryExpression,
   Variable
 };
+use lang\ast\types\{IsValue, IsExpression};
 use unittest\{Assert, Test, Values};
 
 class OperatorTest extends ParseTest {
@@ -138,7 +139,7 @@ class OperatorTest extends ParseTest {
   #[Test]
   public function new_type() {
     $this->assertParsed(
-      [new NewExpression('\\T', [], self::LINE)],
+      [new NewExpression(new IsValue('\\T'), [], self::LINE)],
       'new T();'
     );
   }
@@ -146,7 +147,7 @@ class OperatorTest extends ParseTest {
   #[Test]
   public function new_var() {
     $this->assertParsed(
-      [new NewExpression('$class', [], self::LINE)],
+      [new NewExpression(new IsExpression(new Variable('class')), [], self::LINE)],
       'new $class();'
     );
   }
@@ -154,7 +155,7 @@ class OperatorTest extends ParseTest {
   #[Test]
   public function new_expr() {
     $this->assertParsed(
-      [new NewExpression(new InvokeExpression(new Literal('factory', self::LINE), [], self::LINE), [], self::LINE)],
+      [new NewExpression(new IsExpression(new InvokeExpression(new Literal('factory', self::LINE), [], self::LINE)), [], self::LINE)],
       'new (factory())();'
     );
   }
@@ -162,14 +163,14 @@ class OperatorTest extends ParseTest {
   #[Test]
   public function new_type_with_args() {
     $this->assertParsed(
-      [new NewExpression('\\T', [new Variable('a', self::LINE), new Variable('b', self::LINE)], self::LINE)],
+      [new NewExpression(new IsValue('\\T'), [new Variable('a', self::LINE), new Variable('b', self::LINE)], self::LINE)],
       'new T($a, $b);'
     );
   }
 
   #[Test]
   public function new_anonymous_extends() {
-    $declaration= new ClassDeclaration([], null, '\\T', [], [], null, null, self::LINE);
+    $declaration= new ClassDeclaration([], null, new IsValue('\\T'), [], [], null, null, self::LINE);
     $this->assertParsed(
       [new NewClassExpression($declaration, [], self::LINE)],
       'new class() extends T { };'
@@ -178,7 +179,7 @@ class OperatorTest extends ParseTest {
 
   #[Test]
   public function new_anonymous_implements() {
-    $declaration= new ClassDeclaration([], null, null, ['\\A', '\\B'], [], null, null, self::LINE);
+    $declaration= new ClassDeclaration([], null, null, [new IsValue('\\A'), new IsValue('\\B')], [], null, null, self::LINE);
     $this->assertParsed(
       [new NewClassExpression($declaration, [], self::LINE)],
       'new class() implements A, B { };'

--- a/src/test/php/lang/ast/unittest/parse/TypesTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/TypesTest.class.php
@@ -11,6 +11,7 @@ use lang\ast\nodes\{
   UseExpression,
   Literal
 };
+use lang\ast\types\IsValue;
 use unittest\{Assert, Expect, Test};
 
 class TypesTest extends ParseTest {
@@ -18,7 +19,7 @@ class TypesTest extends ParseTest {
   #[Test]
   public function empty_class() {
     $this->assertParsed(
-      [new ClassDeclaration([], '\\A', null, [], [], null, null, self::LINE)],
+      [new ClassDeclaration([], new IsValue('\\A'), null, [], [], null, null, self::LINE)],
       'class A { }'
     );
   }
@@ -26,7 +27,7 @@ class TypesTest extends ParseTest {
   #[Test]
   public function class_with_parent() {
     $this->assertParsed(
-      [new ClassDeclaration([], '\\A', '\\B', [], [], null, null, self::LINE)],
+      [new ClassDeclaration([], new IsValue('\\A'), new IsValue('\\B'), [], [], null, null, self::LINE)],
       'class A extends B { }'
     );
   }
@@ -34,7 +35,7 @@ class TypesTest extends ParseTest {
   #[Test]
   public function class_with_interface() {
     $this->assertParsed(
-      [new ClassDeclaration([], '\\A', null, ['\\C'], [], null, null, self::LINE)],
+      [new ClassDeclaration([], new IsValue('\\A'), null, [new IsValue('\\C')], [], null, null, self::LINE)],
       'class A implements C { }'
     );
   }
@@ -42,7 +43,7 @@ class TypesTest extends ParseTest {
   #[Test]
   public function class_with_interfaces() {
     $this->assertParsed(
-      [new ClassDeclaration([], '\\A', null, ['\\C', '\\D'], [], null, null, self::LINE)],
+      [new ClassDeclaration([], new IsValue('\\A'), null, [new IsValue('\\C'), new IsValue('\\D')], [], null, null, self::LINE)],
       'class A implements C, D { }'
     );
   }
@@ -50,7 +51,7 @@ class TypesTest extends ParseTest {
   #[Test]
   public function abstract_class() {
     $this->assertParsed(
-      [new ClassDeclaration(['abstract'], '\\A', null, [], [], null, null, self::LINE)],
+      [new ClassDeclaration(['abstract'], new IsValue('\\A'), null, [], [], null, null, self::LINE)],
       'abstract class A { }'
     );
   }
@@ -58,7 +59,7 @@ class TypesTest extends ParseTest {
   #[Test]
   public function final_class() {
     $this->assertParsed(
-      [new ClassDeclaration(['final'], '\\A', null, [], [], null, null, self::LINE)],
+      [new ClassDeclaration(['final'], new IsValue('\\A'), null, [], [], null, null, self::LINE)],
       'final class A { }'
     );
   }
@@ -66,7 +67,7 @@ class TypesTest extends ParseTest {
   #[Test]
   public function empty_interface() {
     $this->assertParsed(
-      [new InterfaceDeclaration([], '\\A', [], [], null, null, self::LINE)],
+      [new InterfaceDeclaration([], new IsValue('\\A'), [], [], null, null, self::LINE)],
       'interface A { }'
     );
   }
@@ -74,7 +75,7 @@ class TypesTest extends ParseTest {
   #[Test]
   public function interface_with_parent() {
     $this->assertParsed(
-      [new InterfaceDeclaration([], '\\A', ['\\B'], [], null, null, self::LINE)],
+      [new InterfaceDeclaration([], new IsValue('\\A'), [new IsValue('\\B')], [], null, null, self::LINE)],
       'interface A extends B { }'
     );
   }
@@ -82,7 +83,7 @@ class TypesTest extends ParseTest {
   #[Test]
   public function interface_with_parents() {
     $this->assertParsed(
-      [new InterfaceDeclaration([], '\\A', ['\\B', '\\C'], [], null, null, self::LINE)],
+      [new InterfaceDeclaration([], new IsValue('\\A'), [new IsValue('\\B'), new IsValue('\\C')], [], null, null, self::LINE)],
       'interface A extends B, C { }'
     );
   }
@@ -90,7 +91,7 @@ class TypesTest extends ParseTest {
   #[Test]
   public function empty_trait() {
     $this->assertParsed(
-      [new TraitDeclaration([], '\\A', [], null, null, self::LINE)],
+      [new TraitDeclaration([], new IsValue('\\A'), [], null, null, self::LINE)],
       'trait A { }'
     );
   }
@@ -98,7 +99,7 @@ class TypesTest extends ParseTest {
   #[Test]
   public function empty_unit_enum() {
     $this->assertParsed(
-      [new EnumDeclaration([], '\\A', null, [], [], null, null, self::LINE)],
+      [new EnumDeclaration([], new IsValue('\\A'), null, [], [], null, null, self::LINE)],
       'enum A { }'
     );
   }
@@ -106,14 +107,14 @@ class TypesTest extends ParseTest {
   #[Test]
   public function empty_backed_enum() {
     $this->assertParsed(
-      [new EnumDeclaration([], '\\A', 'string', [], [], null, null, self::LINE)],
+      [new EnumDeclaration([], new IsValue('\\A'), 'string', [], [], null, null, self::LINE)],
       'enum A: string { }'
     );
   }
 
   #[Test]
   public function unit_enum_with_cases() {
-    $enum= new EnumDeclaration([], '\\A', null, [], [], null, null, self::LINE);
+    $enum= new EnumDeclaration([], new IsValue('\\A'), null, [], [], null, null, self::LINE);
     $enum->declare(new EnumCase('ONE', null, null, null, self::LINE));
     $enum->declare(new EnumCase('TWO', null, null, null, self::LINE));
     $this->assertParsed([$enum], 'enum A { case ONE; case TWO; }');
@@ -121,7 +122,7 @@ class TypesTest extends ParseTest {
 
   #[Test]
   public function backed_enum_with_cases() {
-    $enum= new EnumDeclaration([], '\\A', 'int', [], [], null, null, self::LINE);
+    $enum= new EnumDeclaration([], new IsValue('\\A'), 'int', [], [], null, null, self::LINE);
     $enum->declare(new EnumCase('ONE', new Literal('1', self::LINE), null, null, self::LINE));
     $enum->declare(new EnumCase('TWO', new Literal('2', self::LINE), null, null, self::LINE));
     $this->assertParsed([$enum], 'enum A: int { case ONE = 1; case TWO = 2; }');
@@ -129,7 +130,7 @@ class TypesTest extends ParseTest {
 
   #[Test]
   public function unit_enum_with_grouped_cases() {
-    $enum= new EnumDeclaration([], '\\A', null, [], [], null, null, self::LINE);
+    $enum= new EnumDeclaration([], new IsValue('\\A'), null, [], [], null, null, self::LINE);
     $enum->declare(new EnumCase('ONE', null, null, null, self::LINE));
     $enum->declare(new EnumCase('TWO', null, null, null, self::LINE));
     $this->assertParsed([$enum], 'enum A { case ONE, TWO; }');
@@ -137,14 +138,14 @@ class TypesTest extends ParseTest {
 
   #[Test]
   public function class_with_trait() {
-    $class= new ClassDeclaration([], '\\A', null, [], [], null, null, self::LINE);
+    $class= new ClassDeclaration([], new IsValue('\\A'), null, [], [], null, null, self::LINE);
     $class->body[]= new UseExpression(['\\B'], [], self::LINE);
     $this->assertParsed([$class], 'class A { use B; }');
   }
 
   #[Test]
   public function class_with_multiple_traits() {
-    $class= new ClassDeclaration([], '\\A', null, [], [], null, null, self::LINE);
+    $class= new ClassDeclaration([], new IsValue('\\A'), null, [], [], null, null, self::LINE);
     $class->body[]= new UseExpression(['\\B'], [], self::LINE);
     $class->body[]= new UseExpression(['\\C'], [], self::LINE);
     $this->assertParsed([$class], 'class A { use B; use C; }');
@@ -152,7 +153,7 @@ class TypesTest extends ParseTest {
 
   #[Test]
   public function class_with_comma_separated_traits() {
-    $class= new ClassDeclaration([], '\\A', null, [], [], null, null, self::LINE);
+    $class= new ClassDeclaration([], new IsValue('\\A'), null, [], [], null, null, self::LINE);
     $class->body[]= new UseExpression(['\\B', '\\C'], [], self::LINE);
     $this->assertParsed([$class], 'class A { use B, C; }');
   }
@@ -160,7 +161,7 @@ class TypesTest extends ParseTest {
   #[Test]
   public function class_with_trait_and_aliases() {
     $aliases= ['a' => ['as' => 'first'], '\\B::b' => ['as' => 'second'], '\\C::c' => ['insteadof' => '\\B']];
-    $class= new ClassDeclaration([], '\\A', null, [], [], null, null, self::LINE);
+    $class= new ClassDeclaration([], new IsValue('\\A'), null, [], [], null, null, self::LINE);
     $class->body[]= new UseExpression(['\\B', '\\C'], $aliases, self::LINE + 1);
 
     $this->assertParsed([$class], 'class A {
@@ -175,7 +176,7 @@ class TypesTest extends ParseTest {
   #[Test]
   public function class_in_namespace() {
     $this->assertParsed(
-      [new NamespaceDeclaration('test', self::LINE), new ClassDeclaration([], '\\test\\A', null, [], [], null, null, self::LINE)],
+      [new NamespaceDeclaration('test', self::LINE), new ClassDeclaration([], new IsValue('\\test\\A'), null, [], [], null, null, self::LINE)],
       'namespace test; class A { }'
     );
   }


### PR DESCRIPTION
## Refactoring

This pull request changes uses `lang.ast.Type` subclasses in the following places:

### TypeDeclaration implementations

```diff
+ use lang\ast\Type;
@@ ... @@
  abstract class TypeDeclaration extends Annotated {
-   public string $name;
+   public ?Type $name;
  }
@@ ... @@
  class ClassDeclaration extends TypeDeclaration {
-   public ?string $parent;
-   public array<string> $implements;
+   public ?Type $parent;
+   public array<Type> $implements;
}
@@ ... @@
  class InterfaceDeclaration extends TypeDeclaration {
-   public array<string> $parents;
+   public array<Type> $parents;
}
@@ ... @@
  class EnumDeclaration extends TypeDeclaration {
-   public array<string> $implements;
+   public array<Type> $implements;
}
```

### NewExpression

```diff
- use lang\ast\Node;
+ use lang\ast\{Node, Type};
@@ ... @@
  class NewExpression extends Node {
-   public string|Node $type;
+   public Type $type;
  }
```

### IsGeneric

```diff
  class IsGeneric extends Type {
-   public string $base;
+   public Type $base;
  }
```

It also introduces the `lang.types.IsExpression` class to be used for `new $expr` / `new ($expr)` cases.

## BC break

This introduces as BC break (the XP compiler test suite will fail with *Compile error (Cannot use 'self' as class name, as it is reserved)*, for example), and will thus result in a new major version (9.0 at the time of writing).
