### PR TITLE
Create generic member in lang.ast.nodes.Signature

### DIFF
--- a/src/main/php/lang/ast/nodes/Signature.class.php
+++ b/src/main/php/lang/ast/nodes/Signature.class.php
@@ -4,11 +4,12 @@ use lang\ast\Node;
 
 class Signature extends Node {
   public $kind= 'signature';
-  public $parameters, $returns;
+  public $parameters, $returns, $generic;
 
-  public function __construct($parameters= [], $returns= null, $line= -1) {
+  public function __construct($parameters= [], $returns= null, $generic= null, $line= -1) {
     $this->parameters= $parameters;
     $this->returns= $returns;
+    $this->generic= $generic;
     $this->line= $line;
   }
 

--- a/src/main/php/lang/ast/syntax/PHP.class.php
+++ b/src/main/php/lang/ast/syntax/PHP.class.php
@@ -1417,7 +1417,7 @@ class PHP extends Language {
       $return= null;
     }
 
-    return new Signature($parameters, $return, $line);
+    return new Signature($parameters, $return, null, $line);
   }
 
   public function closure($parse, $static) {

--- a/src/test/php/lang/ast/unittest/parse/ClosuresTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/ClosuresTest.class.php
@@ -23,7 +23,7 @@ class ClosuresTest extends ParseTest {
   #[Test]
   public function with_body() {
     $this->assertParsed(
-      [new ClosureExpression(new Signature([], null, self::LINE), null, [$this->returns], false, self::LINE)],
+      [new ClosureExpression(new Signature([], null, null, self::LINE), null, [$this->returns], false, self::LINE)],
       'function() { return $a + 1; };'
     );
   }
@@ -32,7 +32,7 @@ class ClosuresTest extends ParseTest {
   public function with_param() {
     $params= [new Parameter('a', null, null, false, false, null, null, null, self::LINE)];
     $this->assertParsed(
-      [new ClosureExpression(new Signature($params, null, self::LINE), null, [$this->returns], false, self::LINE)],
+      [new ClosureExpression(new Signature($params, null, null, self::LINE), null, [$this->returns], false, self::LINE)],
       'function($a) { return $a + 1; };'
     );
   }
@@ -40,7 +40,7 @@ class ClosuresTest extends ParseTest {
   #[Test]
   public function with_use_by_value() {
     $this->assertParsed(
-      [new ClosureExpression(new Signature([], null, self::LINE), ['$a', '$b'], [$this->returns], false, self::LINE)],
+      [new ClosureExpression(new Signature([], null, null, self::LINE), ['$a', '$b'], [$this->returns], false, self::LINE)],
       'function() use($a, $b) { return $a + 1; };'
     );
   }
@@ -48,7 +48,7 @@ class ClosuresTest extends ParseTest {
   #[Test]
   public function with_use_by_reference() {
     $this->assertParsed(
-      [new ClosureExpression(new Signature([], null, self::LINE), ['$a', '&$b'], [$this->returns], false, self::LINE)],
+      [new ClosureExpression(new Signature([], null, null, self::LINE), ['$a', '&$b'], [$this->returns], false, self::LINE)],
       'function() use($a, &$b) { return $a + 1; };'
     );
   }
@@ -56,7 +56,7 @@ class ClosuresTest extends ParseTest {
   #[Test]
   public function with_return_type() {
     $this->assertParsed(
-      [new ClosureExpression(new Signature([], new Type('int'), self::LINE), null, [$this->returns], false, self::LINE)],
+      [new ClosureExpression(new Signature([], new Type('int'), null, self::LINE), null, [$this->returns], false, self::LINE)],
       'function(): int { return $a + 1; };'
     );
   }
@@ -64,7 +64,7 @@ class ClosuresTest extends ParseTest {
   #[Test]
   public function with_nullable_return_type() {
     $this->assertParsed(
-      [new ClosureExpression(new Signature([], new Type('?int'), self::LINE), null, [$this->returns], false, self::LINE)],
+      [new ClosureExpression(new Signature([], new Type('?int'), null, self::LINE), null, [$this->returns], false, self::LINE)],
       'function(): ?int { return $a + 1; };'
     );
   }
@@ -72,7 +72,7 @@ class ClosuresTest extends ParseTest {
   #[Test]
   public function static_function() {
     $this->assertParsed(
-      [new ClosureExpression(new Signature([], null, self::LINE), null, [$this->returns], true, self::LINE)],
+      [new ClosureExpression(new Signature([], null, null, self::LINE), null, [$this->returns], true, self::LINE)],
       'static function() { return $a + 1; };'
     );
   }

--- a/src/test/php/lang/ast/unittest/parse/CommentTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/CommentTest.class.php
@@ -146,7 +146,7 @@ class CommentTest extends ParseTest {
   #[Test]
   public function apidoc_comment_attached_to_next_method() {
     $class= new ClassDeclaration([], new IsValue('\\T'), null, [], [], null, null, 2);
-    $class->declare(new Method(['public'], '__construct', new Signature([], null, 4), [], null, new Comment('/** @api */', 3), 4));
+    $class->declare(new Method(['public'], '__construct', new Signature([], null, null, 4), [], null, new Comment('/** @api */', 3), 4));
 
     $this->assertParsed([$class], '
       class T {

--- a/src/test/php/lang/ast/unittest/parse/FunctionsTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/FunctionsTest.class.php
@@ -36,7 +36,7 @@ class FunctionsTest extends ParseTest {
   #[Test]
   public function empty_function_without_parameters() {
     $this->assertParsed(
-      [new FunctionDeclaration('a', new Signature([], null, self::LINE), [], self::LINE)],
+      [new FunctionDeclaration('a', new Signature([], null, null, self::LINE), [], self::LINE)],
       'function a() { }'
     );
   }
@@ -45,8 +45,8 @@ class FunctionsTest extends ParseTest {
   public function two_functions() {
     $this->assertParsed(
       [
-        new FunctionDeclaration('a', new Signature([], null, self::LINE), [], self::LINE),
-        new FunctionDeclaration('b', new Signature([], null, self::LINE), [], self::LINE)
+        new FunctionDeclaration('a', new Signature([], null, null, self::LINE), [], self::LINE),
+        new FunctionDeclaration('b', new Signature([], null, null, self::LINE), [], self::LINE)
       ],
       'function a() { } function b() { }'
     );
@@ -56,7 +56,7 @@ class FunctionsTest extends ParseTest {
   public function with_parameter($name) {
     $params= [new Parameter($name, null, null, false, false, null, null, null, self::LINE)];
     $this->assertParsed(
-      [new FunctionDeclaration('a', new Signature($params, null, self::LINE), [], self::LINE)],
+      [new FunctionDeclaration('a', new Signature($params, null, null, self::LINE), [], self::LINE)],
       'function a($'.$name.') { }'
     );
   }
@@ -65,7 +65,7 @@ class FunctionsTest extends ParseTest {
   public function with_reference_parameter() {
     $params= [new Parameter('param', null, null, true, false, null, null, null, self::LINE)];
     $this->assertParsed(
-      [new FunctionDeclaration('a', new Signature($params, null, self::LINE), [], self::LINE)],
+      [new FunctionDeclaration('a', new Signature($params, null, null, self::LINE), [], self::LINE)],
       'function a(&$param) { }'
     );
   }
@@ -74,7 +74,7 @@ class FunctionsTest extends ParseTest {
   public function dangling_comma_in_parameter_lists() {
     $params= [new Parameter('param', null, null, false, false, null, null, null, self::LINE)];
     $this->assertParsed(
-      [new FunctionDeclaration('a', new Signature($params, null, self::LINE), [], self::LINE)],
+      [new FunctionDeclaration('a', new Signature($params, null, null, self::LINE), [], self::LINE)],
       'function a($param, ) { }'
     );
   }
@@ -83,7 +83,7 @@ class FunctionsTest extends ParseTest {
   public function with_typed_parameter($declaration, $expected) {
     $params= [new Parameter('param', $expected, null, false, false, null, null, null, self::LINE)];
     $this->assertParsed(
-      [new FunctionDeclaration('a', new Signature($params, null, self::LINE), [], self::LINE)],
+      [new FunctionDeclaration('a', new Signature($params, null, null, self::LINE), [], self::LINE)],
       'function a('.$declaration.' $param) { }'
     );
   }
@@ -92,7 +92,7 @@ class FunctionsTest extends ParseTest {
   public function with_nullable_typed_parameter() {
     $params= [new Parameter('param', new IsNullable(new IsLiteral('string')), null, false, false, null, null, null, self::LINE)];
     $this->assertParsed(
-      [new FunctionDeclaration('a', new Signature($params, null, self::LINE), [], self::LINE)],
+      [new FunctionDeclaration('a', new Signature($params, null, null, self::LINE), [], self::LINE)],
       'function a(?string $param) { }'
     );
   }
@@ -101,7 +101,7 @@ class FunctionsTest extends ParseTest {
   public function with_variadic_parameter() {
     $params= [new Parameter('param', null, null, false, true, null, null, null, self::LINE)];
     $this->assertParsed(
-      [new FunctionDeclaration('a', new Signature($params, null, self::LINE), [], self::LINE)],
+      [new FunctionDeclaration('a', new Signature($params, null, null, self::LINE), [], self::LINE)],
       'function a(... $param) { }'
     );
   }
@@ -110,7 +110,7 @@ class FunctionsTest extends ParseTest {
   public function with_optional_parameter() {
     $params= [new Parameter('param', null, new Literal('null', self::LINE), false, false, null, null, null, self::LINE)];
     $this->assertParsed(
-      [new FunctionDeclaration('a', new Signature($params, null, self::LINE), [], self::LINE)],
+      [new FunctionDeclaration('a', new Signature($params, null, null, self::LINE), [], self::LINE)],
       'function a($param= null) { }'
     );
   }
@@ -119,7 +119,7 @@ class FunctionsTest extends ParseTest {
   public function with_parameter_named_function() {
     $params= [new Parameter('function', null, null, false, false, null, null, null, self::LINE)];
     $this->assertParsed(
-      [new FunctionDeclaration('a', new Signature($params, null, self::LINE), [], self::LINE)],
+      [new FunctionDeclaration('a', new Signature($params, null, null, self::LINE), [], self::LINE)],
       'function a($function, ) { }'
     );
   }
@@ -128,7 +128,7 @@ class FunctionsTest extends ParseTest {
   public function with_typed_parameter_named_function() {
     $params= [new Parameter('function', new IsFunction([], new IsLiteral('void')), null, false, false, null, null, null, self::LINE)];
     $this->assertParsed(
-      [new FunctionDeclaration('a', new Signature($params, null, self::LINE), [], self::LINE)],
+      [new FunctionDeclaration('a', new Signature($params, null, null, self::LINE), [], self::LINE)],
       'function a((function(): void) $function) { }'
     );
   }
@@ -136,7 +136,7 @@ class FunctionsTest extends ParseTest {
   #[Test, Values('types')]
   public function with_return_type($declaration, $expected) {
     $this->assertParsed(
-      [new FunctionDeclaration('a', new Signature([], $expected, self::LINE), [], self::LINE)],
+      [new FunctionDeclaration('a', new Signature([], $expected, null, self::LINE), [], self::LINE)],
       'function a(): '.$declaration.' { }'
     );
   }
@@ -145,7 +145,7 @@ class FunctionsTest extends ParseTest {
   public function generator() {
     $yield= new YieldExpression(null, null, self::LINE);
     $this->assertParsed(
-      [new FunctionDeclaration('a', new Signature([], null, self::LINE), [$yield], self::LINE)],
+      [new FunctionDeclaration('a', new Signature([], null, null, self::LINE), [$yield], self::LINE)],
       'function a() { yield; }'
     );
   }
@@ -154,7 +154,7 @@ class FunctionsTest extends ParseTest {
   public function generator_with_value() {
     $yield= new YieldExpression(null, new Literal('1', self::LINE), self::LINE);
     $this->assertParsed(
-      [new FunctionDeclaration('a', new Signature([], null, self::LINE), [$yield], self::LINE)],
+      [new FunctionDeclaration('a', new Signature([], null, null, self::LINE), [$yield], self::LINE)],
       'function a() { yield 1; }'
     );
   }
@@ -163,7 +163,7 @@ class FunctionsTest extends ParseTest {
   public function generator_with_key_and_value() {
     $yield= new YieldExpression(new Literal('"number"', self::LINE), new Literal('1', self::LINE), self::LINE);
     $this->assertParsed(
-      [new FunctionDeclaration('a', new Signature([], null, self::LINE), [$yield], self::LINE)],
+      [new FunctionDeclaration('a', new Signature([], null, null, self::LINE), [$yield], self::LINE)],
       'function a() { yield "number" => 1; }'
     );
   }
@@ -172,7 +172,7 @@ class FunctionsTest extends ParseTest {
   public function generator_delegation() {
     $yield= new YieldFromExpression(new ArrayLiteral([], self::LINE), self::LINE);
     $this->assertParsed(
-      [new FunctionDeclaration('a', new Signature([], null, self::LINE), [$yield], self::LINE)],
+      [new FunctionDeclaration('a', new Signature([], null, null, self::LINE), [$yield], self::LINE)],
       'function a() { yield from []; }'
     );
   }
@@ -186,7 +186,7 @@ class FunctionsTest extends ParseTest {
       self::LINE
     );
     $this->assertParsed(
-      [new FunctionDeclaration('a', new Signature([], null, self::LINE), [$yield], self::LINE)],
+      [new FunctionDeclaration('a', new Signature([], null, null, self::LINE), [$yield], self::LINE)],
       'function a() { $value= yield; }'
     );
   }
@@ -200,7 +200,7 @@ class FunctionsTest extends ParseTest {
       self::LINE
     );
     $this->assertParsed(
-      [new FunctionDeclaration('a', new Signature([], null, self::LINE), [$yield], self::LINE)],
+      [new FunctionDeclaration('a', new Signature([], null, null, self::LINE), [$yield], self::LINE)],
       'function a() { $value= yield (1); }'
     );
   }
@@ -215,7 +215,7 @@ class FunctionsTest extends ParseTest {
       self::LINE
     );
     $this->assertParsed(
-      [new FunctionDeclaration('a', new Signature([], null, self::LINE), [$yield], self::LINE)],
+      [new FunctionDeclaration('a', new Signature([], null, null, self::LINE), [$yield], self::LINE)],
       'function a() { $value= (yield); }'
     );
   }
@@ -229,7 +229,7 @@ class FunctionsTest extends ParseTest {
       self::LINE
     );
     $this->assertParsed(
-      [new FunctionDeclaration('a', new Signature([], null, self::LINE), [$yield], self::LINE)],
+      [new FunctionDeclaration('a', new Signature([], null, null, self::LINE), [$yield], self::LINE)],
       $declaration
     );
   }
@@ -243,7 +243,7 @@ class FunctionsTest extends ParseTest {
       self::LINE
     );
     $this->assertParsed(
-      [new FunctionDeclaration('a', new Signature([], null, self::LINE), [$yield], self::LINE)],
+      [new FunctionDeclaration('a', new Signature([], null, null, self::LINE), [$yield], self::LINE)],
       $declaration
     );
   }

--- a/src/test/php/lang/ast/unittest/parse/LambdasTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/LambdasTest.class.php
@@ -15,7 +15,7 @@ class LambdasTest extends ParseTest {
   #[Test]
   public function short_closure() {
     $this->assertParsed(
-      [new LambdaExpression(new Signature([$this->parameter], null, self::LINE), $this->expression, false, self::LINE)],
+      [new LambdaExpression(new Signature([$this->parameter], null, null, self::LINE), $this->expression, false, self::LINE)],
       'fn($a) => $a + 1;'
     );
   }
@@ -23,7 +23,7 @@ class LambdasTest extends ParseTest {
   #[Test]
   public function static_closure() {
     $this->assertParsed(
-      [new LambdaExpression(new Signature([$this->parameter], null, self::LINE), $this->expression, true, self::LINE)],
+      [new LambdaExpression(new Signature([$this->parameter], null, null, self::LINE), $this->expression, true, self::LINE)],
       'static fn($a) => $a + 1;'
     );
   }
@@ -33,7 +33,7 @@ class LambdasTest extends ParseTest {
     $this->assertParsed(
       [new InvokeExpression(
         new Literal('execute', self::LINE),
-        [new LambdaExpression(new Signature([$this->parameter], null, self::LINE), $this->expression, false, self::LINE)],
+        [new LambdaExpression(new Signature([$this->parameter], null, null, self::LINE), $this->expression, false, self::LINE)],
         self::LINE
       )],
       'execute(fn($a) => $a + 1);'
@@ -44,7 +44,7 @@ class LambdasTest extends ParseTest {
   public function short_closure_with_block() {
     $this->assertParsed(
       [new LambdaExpression(
-        new Signature([$this->parameter], null, self::LINE),
+        new Signature([$this->parameter], null, null, self::LINE),
         new Block([new ReturnStatement($this->expression, self::LINE)], self::LINE),
         false,
         self::LINE

--- a/src/test/php/lang/ast/unittest/parse/MembersTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/MembersTest.class.php
@@ -54,7 +54,7 @@ class MembersTest extends ParseTest {
   #[Test]
   public function private_instance_method() {
     $class= new ClassDeclaration([], new IsValue('\\A'), null, [], [], null, null, self::LINE);
-    $class->declare(new Method(['private'], 'a', new Signature([], null, self::LINE), [], null, null, self::LINE));
+    $class->declare(new Method(['private'], 'a', new Signature([], null, null, self::LINE), [], null, null, self::LINE));
 
     $this->assertParsed([$class], 'class A { private function a() { } }');
   }
@@ -62,7 +62,7 @@ class MembersTest extends ParseTest {
   #[Test]
   public function private_static_method() {
     $class= new ClassDeclaration([], new IsValue('\\A'), null, [], [], null, null, self::LINE);
-    $class->declare(new Method(['private', 'static'], 'a', new Signature([], null, self::LINE), [], null, null, self::LINE));
+    $class->declare(new Method(['private', 'static'], 'a', new Signature([], null, null, self::LINE), [], null, null, self::LINE));
 
     $this->assertParsed([$class], 'class A { private static function a() { } }');
   }
@@ -96,7 +96,7 @@ class MembersTest extends ParseTest {
   public function method_with_typed_parameter($declaration, $expected) {
     $class= new ClassDeclaration([], new IsValue('\\A'), null, [], [], null, null, self::LINE);
     $params= [new Parameter('param', $expected, null, false, false, null, null, null, self::LINE)];
-    $class->declare(new Method(['public'], 'a', new Signature($params, null, self::LINE), [], null, null, self::LINE));
+    $class->declare(new Method(['public'], 'a', new Signature($params, null, null, self::LINE), [], null, null, self::LINE));
 
     $this->assertParsed([$class], 'class A { public function a('.$declaration.' $param) { } }');
   }
@@ -104,7 +104,7 @@ class MembersTest extends ParseTest {
   #[Test, Values('types')]
   public function method_with_return_type($declaration, $expected) {
     $class= new ClassDeclaration([], new IsValue('\\A'), null, [], [], null, null, self::LINE);
-    $class->declare(new Method(['public'], 'a', new Signature([], $expected, self::LINE), [], null, null, self::LINE));
+    $class->declare(new Method(['public'], 'a', new Signature([], $expected, null, self::LINE), [], null, null, self::LINE));
 
     $this->assertParsed([$class], 'class A { public function a(): '.$declaration.' { } }');
   }
@@ -113,7 +113,7 @@ class MembersTest extends ParseTest {
   public function method_with_annotation() {
     $annotations= new Annotations(['Test' => []], self::LINE);
     $class= new ClassDeclaration([], new IsValue('\\A'), null, [], [], null, null, self::LINE);
-    $class->declare(new Method(['public'], 'a', new Signature([], null, self::LINE), [], $annotations, null, self::LINE));
+    $class->declare(new Method(['public'], 'a', new Signature([], null, null, self::LINE), [], $annotations, null, self::LINE));
 
     $this->assertParsed([$class], 'class A { #[Test] public function a() { } }');
   }
@@ -122,7 +122,7 @@ class MembersTest extends ParseTest {
   public function method_with_annotations() {
     $annotations= new Annotations(['Test' => [], 'Ignore' => [new Literal('"Not implemented"', self::LINE)]], self::LINE);
     $class= new ClassDeclaration([], new IsValue('\\A'), null, [], [], null, null, self::LINE);
-    $class->declare(new Method(['public'], 'a', new Signature([], null, self::LINE), [], $annotations, null, self::LINE));
+    $class->declare(new Method(['public'], 'a', new Signature([], null, null, self::LINE), [], $annotations, null, self::LINE));
 
     $this->assertParsed([$class], 'class A { #[Test, Ignore("Not implemented")] public function a() { } }');
   }


### PR DESCRIPTION
This will hold generic type components for methods and functions in the future, e.g.: `function swap<T>(T &$a, T &$b) { }`. Currently, always set to NULL.

*To prevent having to break BC twice, we're suggesting to merge this in 9.0.0*