### PR TITLE
Migrate to new testing library

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,4 +56,4 @@ jobs:
         echo "vendor/autoload.php" > composer.pth
 
     - name: Run test suite
-      run: sh xp-run xp.unittest.TestRunner src/test/php
+      run: sh xp-run xp.test.Runner src/test/php

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
     - name: Install dependencies
       run: >
         curl -sSL https://baltocdn.com/xp-framework/xp-runners/distribution/downloads/e/entrypoint/xp-run-8.6.1.sh > xp-run &&
-        sh composer.sh
+        sh .github/workflows/composer.sh
 
     - name: Run test suite
       run: sh xp-run xp.test.Runner src/test/php

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,8 +52,7 @@ jobs:
     - name: Install dependencies
       run: >
         curl -sSL https://baltocdn.com/xp-framework/xp-runners/distribution/downloads/e/entrypoint/xp-run-8.6.1.sh > xp-run &&
-        COMPOSER_ROOT_VERSION=$(grep '^##' ChangeLog.md | grep -v '?' | head -1 | cut -d ' ' -f 2) composer install --prefer-dist &&
-        echo "vendor/autoload.php" > composer.pth
+        sh composer.sh
 
     - name: Run test suite
       run: sh xp-run xp.test.Runner src/test/php

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
     - name: Install dependencies
       run: >
         curl -sSL https://baltocdn.com/xp-framework/xp-runners/distribution/downloads/e/entrypoint/xp-run-8.6.1.sh > xp-run &&
-        composer install --prefer-dist &&
+        COMPOSER_ROOT_VERSION=$(grep '^##' ChangeLog.md | grep -v '?' | head -1 | cut -d ' ' -f 2) composer install --prefer-dist &&
         echo "vendor/autoload.php" > composer.pth
 
     - name: Run test suite

--- a/.github/workflows/composer.sh
+++ b/.github/workflows/composer.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+COMPOSER_ROOT_VERSION=$(grep '^##' ChangeLog.md | grep -v '?' | head -1 | cut -d ' ' -f 2) composer install --prefer-dist
+echo "vendor/autoload.php" > composer.pth

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     "php" : ">=7.0.0"
   },
   "require-dev" : {
-    "xp-framework/unittest": "^11.0 | ^10.0"
+    "xp-framework/test": "^1.0"
   },
   "autoload" : {
     "files" : ["src/main/php/autoload.php"]

--- a/src/test/php/lang/ast/unittest/AnnotationsTest.class.php
+++ b/src/test/php/lang/ast/unittest/AnnotationsTest.class.php
@@ -2,7 +2,7 @@
 
 use lang\ast\nodes\{Annotation, Annotations, ClassDeclaration};
 use lang\ast\types\IsValue;
-use unittest\{Assert, Before, Test, Values};
+use test\{Assert, Before, Test, Values};
 
 class AnnotationsTest {
   private $annotation;

--- a/src/test/php/lang/ast/unittest/ClassTest.class.php
+++ b/src/test/php/lang/ast/unittest/ClassTest.class.php
@@ -2,7 +2,7 @@
 
 use lang\ast\nodes\{ClassDeclaration, Method, Signature};
 use lang\ast\types\IsValue;
-use unittest\{Assert, Before, Test};
+use test\{Assert, Before, Test};
 
 class ClassTest {
   private $method;

--- a/src/test/php/lang/ast/unittest/LanguageTest.class.php
+++ b/src/test/php/lang/ast/unittest/LanguageTest.class.php
@@ -1,8 +1,8 @@
 <?php namespace lang\ast\unittest;
 
 use lang\IllegalStateException;
-use lang\ast\{Language, Tokens, Errors};
-use unittest\{Assert, Before, Expect, Test};
+use lang\ast\{Errors, Language, Tokens};
+use test\{Assert, Before, Expect, Test};
 
 class LanguageTest {
   private $parse= [];
@@ -37,7 +37,7 @@ class LanguageTest {
     Assert::equals([['test' => 'one']], $fixture->parse(new Tokens('test one;'))->tree()->children());
   }
 
-  #[Test, Expect(class: Errors::class, withMessage: '/Missing semicolon/')]
+  #[Test, Expect(class: Errors::class, message: '/Missing semicolon/')]
   public function missing_semicolon() {
     (new Language())->parse(new Tokens('test'))->tree();
   }

--- a/src/test/php/lang/ast/unittest/LineNumberTest.class.php
+++ b/src/test/php/lang/ast/unittest/LineNumberTest.class.php
@@ -1,7 +1,7 @@
 <?php namespace lang\ast\unittest;
 
-use lang\ast\{Tokens, Language};
-use unittest\{Assert, Test};
+use lang\ast\{Language, Tokens};
+use test\{Assert, Test};
 
 class LineNumberTest {
   private $language;

--- a/src/test/php/lang/ast/unittest/LineNumberTest.class.php
+++ b/src/test/php/lang/ast/unittest/LineNumberTest.class.php
@@ -1,7 +1,7 @@
 <?php namespace lang\ast\unittest;
 
 use lang\ast\{Language, Tokens};
-use test\{Assert, Test};
+use test\{Assert, Before, Test};
 
 class LineNumberTest {
   private $language;

--- a/src/test/php/lang/ast/unittest/ParseTreeTest.class.php
+++ b/src/test/php/lang/ast/unittest/ParseTreeTest.class.php
@@ -1,9 +1,9 @@
 <?php namespace lang\ast\unittest;
 
 use lang\ast\nodes\{ClassDeclaration, NamespaceDeclaration};
-use lang\ast\types\{Compiled, Reflection, IsValue};
+use lang\ast\types\{Compiled, IsValue, Reflection};
 use lang\ast\{ParseTree, Scope};
-use unittest\{Assert, Test, Values};
+use test\{Assert, Test, Values};
 
 class ParseTreeTest {
 

--- a/src/test/php/lang/ast/unittest/ScopeTest.class.php
+++ b/src/test/php/lang/ast/unittest/ScopeTest.class.php
@@ -1,7 +1,7 @@
 <?php namespace lang\ast\unittest;
 
 use lang\ast\Scope;
-use unittest\{Assert, Test};
+use test\{Assert, Test};
 
 class ScopeTest {
 

--- a/src/test/php/lang/ast/unittest/TokensTest.class.php
+++ b/src/test/php/lang/ast/unittest/TokensTest.class.php
@@ -2,7 +2,7 @@
 
 use lang\FormatException;
 use lang\ast\{Language, Tokens};
-use unittest\{Assert, Expect, Test, Values};
+use test\{Assert, Expect, Test, Values};
 
 class TokensTest {
   private $language;
@@ -38,7 +38,7 @@ class TokensTest {
     $this->assertTokens([['string' => $input]], new Tokens($input));
   }
 
-  #[Test, Expect(class: FormatException::class, withMessage: '/Unclosed string literal/'), Values(['"', "'", '"Test', "'Test"])]
+  #[Test, Expect(class: FormatException::class, message: '/Unclosed string literal/'), Values(['"', "'", '"Test', "'Test"])]
   public function unclosed_string_literals($input) {
     (new Tokens($input))->iterator($this->language)->current();
   }

--- a/src/test/php/lang/ast/unittest/TokensTest.class.php
+++ b/src/test/php/lang/ast/unittest/TokensTest.class.php
@@ -2,7 +2,7 @@
 
 use lang\FormatException;
 use lang\ast\{Language, Tokens};
-use test\{Assert, Expect, Test, Values};
+use test\{Assert, Before, Expect, Test, Values};
 
 class TokensTest {
   private $language;

--- a/src/test/php/lang/ast/unittest/TypeTest.class.php
+++ b/src/test/php/lang/ast/unittest/TypeTest.class.php
@@ -2,7 +2,7 @@
 
 use lang\ast\types\{IsArray, IsGeneric, IsLiteral, IsMap, IsNullable, IsValue};
 use lang\ast\{Language, Tokens, Type};
-use unittest\{Assert, Test, Values};
+use test\{Assert, Test, Values};
 
 class TypeTest {
 

--- a/src/test/php/lang/ast/unittest/nodes/ArrayLiteralTest.class.php
+++ b/src/test/php/lang/ast/unittest/nodes/ArrayLiteralTest.class.php
@@ -1,7 +1,7 @@
 <?php namespace lang\ast\unittest\nodes;
 
 use lang\ast\nodes\{ArrayLiteral, Literal};
-use unittest\{Assert, Test};
+use test\{Assert, Test};
 
 class ArrayLiteralTest extends NodeTest {
 

--- a/src/test/php/lang/ast/unittest/nodes/CaseLabelTest.class.php
+++ b/src/test/php/lang/ast/unittest/nodes/CaseLabelTest.class.php
@@ -1,7 +1,7 @@
 <?php namespace lang\ast\unittest\nodes;
 
 use lang\ast\nodes\{CaseLabel, Literal};
-use unittest\{Assert, Before, Test};
+use test\{Assert, Before, Test};
 
 class CaseLabelTest extends NodeTest {
   private $expression;

--- a/src/test/php/lang/ast/unittest/nodes/CatchStatementTest.class.php
+++ b/src/test/php/lang/ast/unittest/nodes/CatchStatementTest.class.php
@@ -2,7 +2,7 @@
 
 use lang\IllegalArgumentException;
 use lang\ast\nodes\{CatchStatement, Variable};
-use unittest\{Assert, Before, Test};
+use test\{Assert, Before, Test};
 
 class CatchStatementTest extends NodeTest {
   private $types;

--- a/src/test/php/lang/ast/unittest/nodes/IfStatementTest.class.php
+++ b/src/test/php/lang/ast/unittest/nodes/IfStatementTest.class.php
@@ -1,7 +1,7 @@
 <?php namespace lang\ast\unittest\nodes;
 
 use lang\ast\nodes\{IfStatement, Variable};
-use unittest\{Assert, Before, Test};
+use test\{Assert, Before, Test};
 
 class IfStatementTest extends NodeTest {
   private $condition;

--- a/src/test/php/lang/ast/unittest/nodes/LiteralTest.class.php
+++ b/src/test/php/lang/ast/unittest/nodes/LiteralTest.class.php
@@ -1,7 +1,7 @@
 <?php namespace lang\ast\unittest\nodes;
 
 use lang\ast\nodes\Literal;
-use unittest\{Assert, Test};
+use test\{Assert, Test};
 
 class LiteralTest extends NodeTest {
 

--- a/src/test/php/lang/ast/unittest/nodes/ReturnStatementTest.class.php
+++ b/src/test/php/lang/ast/unittest/nodes/ReturnStatementTest.class.php
@@ -1,7 +1,7 @@
 <?php namespace lang\ast\unittest\nodes;
 
 use lang\ast\nodes\{Literal, ReturnStatement};
-use unittest\{Assert, Test};
+use test\{Assert, Test};
 
 class ReturnStatementTest extends NodeTest {
 

--- a/src/test/php/lang/ast/unittest/nodes/SwitchStatementTest.class.php
+++ b/src/test/php/lang/ast/unittest/nodes/SwitchStatementTest.class.php
@@ -1,7 +1,7 @@
 <?php namespace lang\ast\unittest\nodes;
 
 use lang\ast\nodes\{CaseLabel, Literal, SwitchStatement, Variable};
-use unittest\{Assert, Test};
+use test\{Assert, Test};
 
 class SwitchStatementTest extends NodeTest {
   private $expression;

--- a/src/test/php/lang/ast/unittest/parse/AttributesTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/AttributesTest.class.php
@@ -1,7 +1,7 @@
 <?php namespace lang\ast\unittest\parse;
 
 use lang\ast\nodes\{Annotated, ArrayLiteral, Literal};
-use unittest\{Assert, Test, Values};
+use test\{Assert, Test, Values};
 
 /** @see https://wiki.php.net/rfc/shorter_attribute_syntax_change */
 class AttributesTest extends ParseTest {
@@ -160,75 +160,75 @@ class AttributesTest extends ParseTest {
   }
 
 
-  #[Test, Values('attributes')]
+  #[Test, Values(from: 'attributes')]
   public function on_function($attributes, $expected) {
     $tree= $this->parse($attributes.' function fixture() { }')->tree();
     $this->assertAnnotated($expected, $tree->children()[0]);
   }
 
-  #[Test, Values('attributes')]
+  #[Test, Values(from: 'attributes')]
   public function on_anonymous_class($attributes, $expected) {
     $tree= $this->parse('new '.$attributes.' class() { };')->tree();
     $this->assertAnnotated($expected, $tree->children()[0]->definition);
   }
 
-  #[Test, Values('attributes')]
+  #[Test, Values(from: 'attributes')]
   public function on_closure($attributes, $expected) {
     $tree= $this->parse($attributes.' function() { };')->tree();
     $this->assertAnnotated($expected, $tree->children()[0]);
   }
 
-  #[Test, Values('attributes')]
+  #[Test, Values(from: 'attributes')]
   public function on_lambda($attributes, $expected) {
     $tree= $this->parse($attributes.' fn() => true;')->tree();
     $this->assertAnnotated($expected, $tree->children()[0]);
   }
 
-  #[Test, Values('attributes')]
+  #[Test, Values(from: 'attributes')]
   public function on_class($attributes, $expected) {
     $this->assertAnnotated($expected, $this->type($attributes.' class T { }'));
   }
 
-  #[Test, Values('attributes')]
+  #[Test, Values(from: 'attributes')]
   public function on_trait($attributes, $expected) {
     $this->assertAnnotated($expected, $this->type($attributes.' trait T { }'));
   }
 
-  #[Test, Values('attributes')]
+  #[Test, Values(from: 'attributes')]
   public function on_interface($attributes, $expected) {
     $this->assertAnnotated($expected, $this->type($attributes.' interface T { }'));
   }
 
-  #[Test, Values('attributes')]
+  #[Test, Values(from: 'attributes')]
   public function on_enum($attributes, $expected) {
     $this->assertAnnotated($expected, $this->type($attributes.' enum T { }'));
   }
 
-  #[Test, Values('attributes')]
+  #[Test, Values(from: 'attributes')]
   public function on_constant($attributes, $expected) {
     $type= $this->type('class T { '.$attributes.' const FIXTURE = 1; }');
     $this->assertAnnotated($expected, $type->constant('FIXTURE'));
   }
 
-  #[Test, Values('attributes')]
+  #[Test, Values(from: 'attributes')]
   public function on_property($attributes, $expected) {
     $type= $this->type('class T { '.$attributes.' public $fixture; }');
     $this->assertAnnotated($expected, $type->property('fixture'));
   }
 
-  #[Test, Values('attributes')]
+  #[Test, Values(from: 'attributes')]
   public function on_method($attributes, $expected) {
     $type= $this->type('class T { '.$attributes.' public function fixture() { } }');
     $this->assertAnnotated($expected, $type->method('fixture'));
   }
 
-  #[Test, Values('attributes')]
+  #[Test, Values(from: 'attributes')]
   public function on_parameter($attributes, $expected) {
     $type= $this->type('class T { public function fixture('.$attributes.' $p) { } }');
     $this->assertAnnotated($expected, $type->method('fixture')->signature->parameters[0]);
   }
 
-  #[Test, Values('attributes')]
+  #[Test, Values(from: 'attributes')]
   public function on_enum_case($attributes, $expected) {
     $type= $this->type('enum T { '.$attributes.' case ONE; }');
     $this->assertAnnotated($expected, $type->case('ONE'));

--- a/src/test/php/lang/ast/unittest/parse/BlocksTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/BlocksTest.class.php
@@ -1,7 +1,7 @@
 <?php namespace lang\ast\unittest\parse;
 
 use lang\ast\nodes\{Block, InvokeExpression, Literal};
-use unittest\{Assert, Test};
+use test\{Assert, Test};
 
 class BlocksTest extends ParseTest {
 

--- a/src/test/php/lang/ast/unittest/parse/CastTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/CastTest.class.php
@@ -1,8 +1,8 @@
 <?php namespace lang\ast\unittest\parse;
 
 use lang\ast\nodes\{CastExpression, Variable};
-use lang\ast\types\{IsArray, IsLiteral, IsMap, IsNullable, IsValue, IsGeneric, IsFunction, IsUnion, IsIntersection};
-use unittest\{Assert, Test, Values};
+use lang\ast\types\{IsArray, IsFunction, IsGeneric, IsIntersection, IsLiteral, IsMap, IsNullable, IsUnion, IsValue};
+use test\{Assert, Test, Values};
 
 class CastTest extends ParseTest {
 
@@ -36,7 +36,7 @@ class CastTest extends ParseTest {
     yield ['Map<string, Value>', new IsGeneric(new IsValue('Map'), [new IsLiteral('string'), new IsValue('Value')])];
   }
 
-  #[Test, Values('types')]
+  #[Test, Values(from: 'types')]
   public function simple($type, $expected) {
     $this->assertParsed(
       [new CastExpression($expected, new Variable('a', self::LINE), self::LINE)],
@@ -44,7 +44,7 @@ class CastTest extends ParseTest {
     );
   }
 
-  #[Test, Values('types')]
+  #[Test, Values(from: 'types')]
   public function array_of($type, $expected) {
     $this->assertParsed(
       [new CastExpression(new IsArray($expected), new Variable('a', self::LINE), self::LINE)],
@@ -52,7 +52,7 @@ class CastTest extends ParseTest {
     );
   }
 
-  #[Test, Values('types')]
+  #[Test, Values(from: 'types')]
   public function map_of($type, $expected) {
     $this->assertParsed(
       [new CastExpression(new IsMap(new IsLiteral('string'), $expected), new Variable('a', self::LINE), self::LINE)],
@@ -60,7 +60,7 @@ class CastTest extends ParseTest {
     );
   }
 
-  #[Test, Values('types')]
+  #[Test, Values(from: 'types')]
   public function union_of($type, $expected) {
     $this->assertParsed(
       [new CastExpression(new IsUnion([new IsLiteral('string'), $expected]), new Variable('a', self::LINE), self::LINE)],
@@ -68,7 +68,7 @@ class CastTest extends ParseTest {
     );
   }
 
-  #[Test, Values('types')]
+  #[Test, Values(from: 'types')]
   public function intersection_of($type, $expected) {
     $this->assertParsed(
       [new CastExpression(new IsIntersection([new IsLiteral('string'), $expected]), new Variable('a', self::LINE), self::LINE)],

--- a/src/test/php/lang/ast/unittest/parse/ClosuresTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/ClosuresTest.class.php
@@ -2,7 +2,7 @@
 
 use lang\ast\nodes\{BinaryExpression, ClosureExpression, Literal, Parameter, ReturnStatement, Signature, Variable};
 use lang\ast\{FunctionType, Type};
-use unittest\{Assert, Before, Test};
+use test\{Assert, Before, Test};
 
 class ClosuresTest extends ParseTest {
   private $returns;

--- a/src/test/php/lang/ast/unittest/parse/CommentTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/CommentTest.class.php
@@ -1,8 +1,8 @@
 <?php namespace lang\ast\unittest\parse;
 
-use lang\ast\nodes\{Annotations, ClassDeclaration, Comment, Constant, Property, Method, Signature, Literal};
+use lang\ast\nodes\{Annotations, ClassDeclaration, Comment, Constant, Literal, Method, Property, Signature};
 use lang\ast\types\IsValue;
-use unittest\{Assert, Test};
+use test\{Assert, Test};
 
 class CommentTest extends ParseTest {
 

--- a/src/test/php/lang/ast/unittest/parse/ConditionalTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/ConditionalTest.class.php
@@ -2,7 +2,7 @@
 
 use lang\ast\Errors;
 use lang\ast\nodes\{CaseLabel, IfStatement, InvokeExpression, Literal, MatchCondition, MatchExpression, ScopeExpression, SwitchStatement, Variable};
-use unittest\{Assert, Before, Test};
+use test\{Assert, Before, Expect, Test};
 
 class ConditionalTest extends ParseTest {
   private $blocks;
@@ -145,7 +145,7 @@ class ConditionalTest extends ParseTest {
     );
   }
 
-  #[Test, Expect(class: Errors::class, withMessage: 'Unexpected (end)')]
+  #[Test, Expect(class: Errors::class, message: 'Unexpected (end)')]
   public function unclosed_statement_list() {
     $this->parse('if ($condition) { action1();')->stream()->current();
   }

--- a/src/test/php/lang/ast/unittest/parse/ConditionalTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/ConditionalTest.class.php
@@ -145,7 +145,7 @@ class ConditionalTest extends ParseTest {
     );
   }
 
-  #[Test, Expect(class: Errors::class, message: 'Unexpected (end)')]
+  #[Test, Expect(class: Errors::class, message: '/Unexpected \(end\)/')]
   public function unclosed_statement_list() {
     $this->parse('if ($condition) { action1();')->stream()->current();
   }

--- a/src/test/php/lang/ast/unittest/parse/DestructuringTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/DestructuringTest.class.php
@@ -1,7 +1,7 @@
 <?php namespace lang\ast\unittest\parse;
 
 use lang\ast\nodes\{ArrayLiteral, Literal, Variable};
-use unittest\{Assert, Test, Values};
+use test\{Assert, Test, Values};
 
 class DestructuringTest extends ParseTest {
 

--- a/src/test/php/lang/ast/unittest/parse/ErrorsTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/ErrorsTest.class.php
@@ -1,7 +1,7 @@
 <?php namespace lang\ast\unittest\parse;
 
 use lang\ast\Errors;
-use unittest\{Assert, Test, AssertionFailedError};
+use test\{Assert, AssertionFailedError, Test, Values};
 
 class ErrorsTest extends ParseTest {
 

--- a/src/test/php/lang/ast/unittest/parse/FunctionsTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/FunctionsTest.class.php
@@ -15,7 +15,7 @@ use lang\ast\nodes\{
   YieldFromExpression
 };
 use lang\ast\types\{IsFunction, IsLiteral, IsNullable, IsUnion, IsValue};
-use unittest\{Assert, Test, Values};
+use test\{Assert, Test, Values};
 
 class FunctionsTest extends ParseTest {
 
@@ -79,7 +79,7 @@ class FunctionsTest extends ParseTest {
     );
   }
 
-  #[Test, Values('types')]
+  #[Test, Values(from: 'types')]
   public function with_typed_parameter($declaration, $expected) {
     $params= [new Parameter('param', $expected, null, false, false, null, null, null, self::LINE)];
     $this->assertParsed(
@@ -133,7 +133,7 @@ class FunctionsTest extends ParseTest {
     );
   }
 
-  #[Test, Values('types')]
+  #[Test, Values(from: 'types')]
   public function with_return_type($declaration, $expected) {
     $this->assertParsed(
       [new FunctionDeclaration('a', new Signature([], $expected, null, self::LINE), [], self::LINE)],

--- a/src/test/php/lang/ast/unittest/parse/InvokeTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/InvokeTest.class.php
@@ -12,7 +12,7 @@ use lang\ast\nodes\{
   Variable
 };
 use lang\ast\types\IsValue;
-use unittest\{Assert, Test};
+use test\{Assert, Test};
 
 /**
  * Invocation expressions

--- a/src/test/php/lang/ast/unittest/parse/LambdasTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/LambdasTest.class.php
@@ -1,7 +1,7 @@
 <?php namespace lang\ast\unittest\parse;
 
-use lang\ast\nodes\{BinaryExpression, InvokeExpression, LambdaExpression, Literal, Parameter, ReturnStatement, Signature, Variable, Block};
-use unittest\{Assert, Before, Test};
+use lang\ast\nodes\{BinaryExpression, Block, InvokeExpression, LambdaExpression, Literal, Parameter, ReturnStatement, Signature, Variable};
+use test\{Assert, Before, Test};
 
 class LambdasTest extends ParseTest {
   private $expression, $parameter;

--- a/src/test/php/lang/ast/unittest/parse/LiteralsTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/LiteralsTest.class.php
@@ -1,7 +1,7 @@
 <?php namespace lang\ast\unittest\parse;
 
 use lang\ast\nodes\{ArrayLiteral, Literal};
-use unittest\{Assert, Test, Values};
+use test\{Assert, Test, Values};
 
 class LiteralsTest extends ParseTest {
 

--- a/src/test/php/lang/ast/unittest/parse/LoopsTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/LoopsTest.class.php
@@ -1,7 +1,22 @@
 <?php namespace lang\ast\unittest\parse;
 
-use lang\ast\nodes\{Assignment, BinaryExpression, BreakStatement, ContinueStatement, DoLoop, ForLoop, ForeachLoop, GotoStatement, InvokeExpression, Label, Literal, UnaryExpression, Variable, WhileLoop};
-use unittest\{Assert, Before, Test};
+use lang\ast\nodes\{
+  Assignment,
+  BinaryExpression,
+  BreakStatement,
+  ContinueStatement,
+  DoLoop,
+  ForLoop,
+  ForeachLoop,
+  GotoStatement,
+  InvokeExpression,
+  Label,
+  Literal,
+  UnaryExpression,
+  Variable,
+  WhileLoop
+};
+use test\{Assert, Before, Test};
 
 class LoopsTest extends ParseTest {
   private $loop;

--- a/src/test/php/lang/ast/unittest/parse/MatchExpressionTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/MatchExpressionTest.class.php
@@ -11,7 +11,7 @@ use lang\ast\nodes\{
   NewExpression
 };
 use lang\ast\types\IsValue;
-use unittest\{Assert, Test};
+use test\{Assert, Test};
 
 class MatchExpressionTest extends ParseTest {
 

--- a/src/test/php/lang/ast/unittest/parse/MembersTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/MembersTest.class.php
@@ -16,7 +16,7 @@ use lang\ast\nodes\{
   Parameter
 };
 use lang\ast\types\{IsFunction, IsLiteral, IsNullable, IsUnion, IsValue};
-use unittest\{Assert, Test, Values};
+use test\{Assert, Test, Values};
 
 class MembersTest extends ParseTest {
 
@@ -92,7 +92,7 @@ class MembersTest extends ParseTest {
     $this->assertParsed([$class], 'class A { private const T = 1; }');
   }
 
-  #[Test, Values('types')]
+  #[Test, Values(from: 'types')]
   public function method_with_typed_parameter($declaration, $expected) {
     $class= new ClassDeclaration([], new IsValue('\\A'), null, [], [], null, null, self::LINE);
     $params= [new Parameter('param', $expected, null, false, false, null, null, null, self::LINE)];
@@ -101,7 +101,7 @@ class MembersTest extends ParseTest {
     $this->assertParsed([$class], 'class A { public function a('.$declaration.' $param) { } }');
   }
 
-  #[Test, Values('types')]
+  #[Test, Values(from: 'types')]
   public function method_with_return_type($declaration, $expected) {
     $class= new ClassDeclaration([], new IsValue('\\A'), null, [], [], null, null, self::LINE);
     $class->declare(new Method(['public'], 'a', new Signature([], $expected, null, self::LINE), [], null, null, self::LINE));

--- a/src/test/php/lang/ast/unittest/parse/NamedArgumentsTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/NamedArgumentsTest.class.php
@@ -1,7 +1,7 @@
 <?php namespace lang\ast\unittest\parse;
 
 use lang\ast\nodes\{InstanceExpression, InvokeExpression, Literal, Variable};
-use unittest\{Assert, Test};
+use test\{Assert, Test};
 
 /**
  * Named argumwents

--- a/src/test/php/lang/ast/unittest/parse/NamespacesTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/NamespacesTest.class.php
@@ -1,7 +1,7 @@
 <?php namespace lang\ast\unittest\parse;
 
 use lang\ast\nodes\{NamespaceDeclaration, UseStatement};
-use unittest\{Assert, Test};
+use test\{Assert, Test};
 
 class NamespacesTest extends ParseTest {
 

--- a/src/test/php/lang/ast/unittest/parse/OperatorTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/OperatorTest.class.php
@@ -18,8 +18,8 @@ use lang\ast\nodes\{
   UnaryExpression,
   Variable
 };
-use lang\ast\types\{IsValue, IsExpression};
-use unittest\{Assert, Test, Values};
+use lang\ast\types\{IsExpression, IsValue};
+use test\{Assert, Test, Values};
 
 class OperatorTest extends ParseTest {
 

--- a/src/test/php/lang/ast/unittest/parse/ParseTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/ParseTest.class.php
@@ -2,7 +2,7 @@
 
 use lang\ast\{Language, Parse, Tokens};
 use text\StringTokenizer;
-use unittest\Assert;
+use test\Assert;
 
 abstract class ParseTest {
   const LINE = 1;

--- a/src/test/php/lang/ast/unittest/parse/StartTokensTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/StartTokensTest.class.php
@@ -1,8 +1,8 @@
 <?php namespace lang\ast\unittest\parse;
 
 use lang\ast\Errors;
-use lang\ast\nodes\{NamespaceDeclaration, Directives, Literal};
-use unittest\{Assert, Test};
+use lang\ast\nodes\{Directives, Literal, NamespaceDeclaration};
+use test\{Assert, Expect, Test};
 
 class StartTokensTest extends ParseTest {
 
@@ -32,7 +32,7 @@ class StartTokensTest extends ParseTest {
     );
   }
 
-  #[Test, Expect(class: Errors::class, withMessage: 'Unexpected syntax hh, expecting php in <?')]
+  #[Test, Expect(class: Errors::class, message: 'Unexpected syntax hh, expecting php in <?')]
   public function hack() {
     $this->parse('<?hh namespace test;')->tree();
   }

--- a/src/test/php/lang/ast/unittest/parse/StartTokensTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/StartTokensTest.class.php
@@ -32,7 +32,7 @@ class StartTokensTest extends ParseTest {
     );
   }
 
-  #[Test, Expect(class: Errors::class, message: 'Unexpected syntax hh, expecting php in <?')]
+  #[Test, Expect(class: Errors::class, message: '/Unexpected syntax hh, expecting php in <\\?/')]
   public function hack() {
     $this->parse('<?hh namespace test;')->tree();
   }

--- a/src/test/php/lang/ast/unittest/parse/TypeParsingTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/TypeParsingTest.class.php
@@ -1,8 +1,8 @@
 <?php namespace lang\ast\unittest\parse;
 
-use lang\ast\types\{IsLiteral, IsArray, IsMap, IsValue, IsFunction, IsGeneric, IsNullable, IsUnion, IsIntersection};
+use lang\ast\types\{IsArray, IsFunction, IsGeneric, IsIntersection, IsLiteral, IsMap, IsNullable, IsUnion, IsValue};
 use lang\ast\{Language, Parse, Tokens};
-use unittest\{Assert, Test, Values};
+use test\{Assert, Test, Values};
 
 class TypeParsingTest {
 
@@ -76,37 +76,37 @@ class TypeParsingTest {
     Assert::equals(new IsValue($declaration), $this->parse($declaration));
   }
 
-  #[Test, Values('arrays')]
+  #[Test, Values(from: 'arrays')]
   public function array_type($declaration, $component) {
     Assert::equals(new IsArray($component), $this->parse($declaration));
   }
 
-  #[Test, Values('maps')]
+  #[Test, Values(from: 'maps')]
   public function map_type($declaration, $key, $value) {
     Assert::equals(new IsMap($key, $value), $this->parse($declaration));
   }
 
-  #[Test, Values('generics')]
+  #[Test, Values(from: 'generics')]
   public function generic_type($declaration, $base, $components) {
     Assert::equals(new IsGeneric($base, $components), $this->parse($declaration));
   }
 
-  #[Test, Values('functions')]
+  #[Test, Values(from: 'functions')]
   public function function_type($declaration, $arguments, $returns) {
     Assert::equals(new IsFunction($arguments, $returns), $this->parse($declaration));
   }
 
-  #[Test, Values('unions')]
+  #[Test, Values(from: 'unions')]
   public function union_type($declaration, $components) {
     Assert::equals(new IsUnion($components), $this->parse($declaration));
   }
 
-  #[Test, Values('intersections')]
+  #[Test, Values(from: 'intersections')]
   public function intersection_type($declaration, $components) {
     Assert::equals(new IsIntersection($components), $this->parse($declaration));
   }
 
-  #[Test, Values('nullables')]
+  #[Test, Values(from: 'nullables')]
   public function nullable_type($declaration, $type) {
     Assert::equals(new IsNullable($type), $this->parse($declaration));
   }

--- a/src/test/php/lang/ast/unittest/parse/TypesTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/TypesTest.class.php
@@ -12,7 +12,7 @@ use lang\ast\nodes\{
   Literal
 };
 use lang\ast\types\IsValue;
-use unittest\{Assert, Expect, Test};
+use test\{Assert, Expect, Test};
 
 class TypesTest extends ParseTest {
 
@@ -181,17 +181,17 @@ class TypesTest extends ParseTest {
     );
   }
 
-  #[Test, Expect(['class' => Errors::class, 'withMessage' => 'Cannot redeclare method b()'])]
+  #[Test, Expect(class: Errors::class, message: '/Cannot redeclare method b\(\)/')]
   public function cannot_redeclare_method() {
     $this->parse('class A { public function b() { } public function b() { }}')->tree();
   }
 
-  #[Test, Expect(['class' => Errors::class, 'withMessage' => 'Cannot redeclare property $b'])]
+  #[Test, Expect(class: Errors::class, message: '/Cannot redeclare property \$b/')]
   public function cannot_redeclare_property() {
     $this->parse('class A { public $b; private $b; }')->tree();
   }
 
-  #[Test, Expect(['class' => Errors::class, 'withMessage' => 'Cannot redeclare constant B'])]
+  #[Test, Expect(class: Errors::class, message: '/Cannot redeclare constant B/')]
   public function cannot_redeclare_constant() {
     $this->parse('class A { const B = 1; const B = 3; }')->tree();
   }

--- a/src/test/php/lang/ast/unittest/parse/VariablesTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/VariablesTest.class.php
@@ -1,7 +1,7 @@
 <?php namespace lang\ast\unittest\parse;
 
 use lang\ast\nodes\{Literal, OffsetExpression, StaticLocals, Variable};
-use unittest\{Assert, Test, Values};
+use test\{Assert, Test, Values};
 
 class VariablesTest extends ParseTest {
 


### PR DESCRIPTION
See https://github.com/xp-framework/rfc/issues/344 and https://github.com/xp-framework/test. Mostly migrated automatically, needed fixes for missing imports, old `Expect(['class' => ...])` syntax and incorrectly rewritten multi-line `use` statements.