### PR TITLE
Implement unchecked types

### DIFF
--- a/src/main/php/lang/ast/syntax/PHP.class.php
+++ b/src/main/php/lang/ast/syntax/PHP.class.php
@@ -71,6 +71,7 @@ use lang\ast\types\{
   IsLiteral,
   IsMap,
   IsNullable,
+  IsUnchecked,
   IsUnion,
   IsValue
 };
@@ -1338,7 +1339,12 @@ class PHP extends Language {
         $promote= null;
       }
 
-      $type= $this->type($parse);
+      if ('@' === $parse->token->value) {
+        $parse->forward();
+        $type= new IsUnchecked($this->type($parse));
+      } else {
+        $type= $this->type($parse);
+      }
 
       if ('...' !== $parse->token->value) {
         $variadic= false;

--- a/src/main/php/lang/ast/types/IsUnchecked.class.php
+++ b/src/main/php/lang/ast/types/IsUnchecked.class.php
@@ -1,0 +1,32 @@
+<?php namespace lang\ast\types;
+
+use lang\ast\Type;
+
+class IsUnchecked extends Type {
+  public $element;
+
+  /**
+   * Creates a new element
+   *
+   * @param  parent $element
+   */
+  public function __construct(Type $element) {
+    $this->element= $element;
+  }
+
+  /** @return string */
+  public function literal() { return $this->element->literal(); }
+
+  /** @return string */
+  public function name() { return $this->element->name(); }
+
+  /**
+   * Compare
+   *
+   * @param  var $value
+   * @return int
+   */
+  public function compareTo($value) {
+    return $value instanceof self ? $this->element->compareTo($value->element) : 1;
+  }
+}


### PR DESCRIPTION
These types only end up in the type meta information. XP reflection reports the types via `getType()`, while `getTypeRestriction()` is *NULL*.

```php
function verified(string $param) { }
function unchecked(@string $param) { }

verified(null);  // Exception
unchecked(null); // Works
```

See https://github.com/xp-framework/compiler/issues/119#issuecomment-1427022356