### PR TITLE
Implement returning by reference from methods

### DIFF
--- a/src/main/php/lang/ast/nodes/Signature.class.php
+++ b/src/main/php/lang/ast/nodes/Signature.class.php
@@ -4,12 +4,12 @@ use lang\ast\Node;
 
 class Signature extends Node {
   public $kind= 'signature';
-  public $parameters, $returns, $generic;
+  public $parameters, $returns, $byref;
 
-  public function __construct($parameters= [], $returns= null, $generic= null, $line= -1) {
+  public function __construct($parameters= [], $returns= null, $byref= false, $line= -1) {
     $this->parameters= $parameters;
     $this->returns= $returns;
-    $this->generic= $generic;
+    $this->byref= $byref;
     $this->line= $line;
   }
 

--- a/src/main/php/lang/ast/syntax/PHP.class.php
+++ b/src/main/php/lang/ast/syntax/PHP.class.php
@@ -826,10 +826,9 @@ class PHP extends Language {
     });
 
     $this->stmt('function', function($parse, $token) {
-      $name= $parse->token->value;
 
       // Function expression used as statement (e.g. for pure side-effects!)
-      if ('(' === $name) {
+      if ('(' === $parse->token->value) {
         $parse->queue= [$parse->token];
         $parse->token= new Token($this->symbol('function'));
         $parse->token->line= $token->line;
@@ -840,8 +839,17 @@ class PHP extends Language {
         return $expr;
       }
 
+      if ('&' === $parse->token->value) {
+        $byref= true;
+        $parse->forward();
+      } else {
+        $byref= false;
+      }
+
+      $name= $parse->token->value;
       $parse->forward();
-      $signature= $this->signature($parse);
+
+      $signature= $this->signature($parse, $byref);
       $parse->expecting('{', 'function');
       $statements= $this->statements($parse);
       $parse->expecting('}', 'function');
@@ -1058,6 +1066,13 @@ class PHP extends Language {
       $line= $parse->token->line;
 
       $parse->forward();
+      if ('&' === $parse->token->value) {
+        $byref= true;
+        $parse->forward();
+      } else {
+        $byref= false;
+      }
+
       $name= $parse->token->value;
       $lookup= $name.'()';
       if (isset($body[$lookup])) {
@@ -1065,7 +1080,7 @@ class PHP extends Language {
       }
 
       $parse->forward();
-      $signature= $this->signature($parse);
+      $signature= $this->signature($parse, $byref);
 
       if ('{' === $parse->token->value) {          // Regular body
         $parse->forward();
@@ -1448,7 +1463,7 @@ class PHP extends Language {
     return $body;
   }
 
-  public function signature($parse) {
+  public function signature($parse, $byref= false) {
     $line= $parse->token->line;
     $parse->expecting('(', 'signature');
     $parameters= $this->parameters($parse);
@@ -1461,7 +1476,7 @@ class PHP extends Language {
       $return= null;
     }
 
-    return new Signature($parameters, $return, null, $line);
+    return new Signature($parameters, $return, $byref, $line);
   }
 
   public function closure($parse, $static) {

--- a/src/test/php/lang/ast/unittest/parse/BracedTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/BracedTest.class.php
@@ -66,7 +66,7 @@ class BracedTest extends ParseTest {
     $signature= new Signature(
       [new Parameter('arg', new IsValue('\\T'), null, true, false, null, null, null, self::LINE)],
       null,
-      null,
+      false,
       self::LINE
     );
     $this->assertParsed(

--- a/src/test/php/lang/ast/unittest/parse/ClosuresTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/ClosuresTest.class.php
@@ -23,7 +23,7 @@ class ClosuresTest extends ParseTest {
   #[Test]
   public function with_body() {
     $this->assertParsed(
-      [new ClosureExpression(new Signature([], null, null, self::LINE), null, [$this->returns], false, self::LINE)],
+      [new ClosureExpression(new Signature([], null, false, self::LINE), null, [$this->returns], false, self::LINE)],
       'function() { return $a + 1; };'
     );
   }
@@ -32,7 +32,7 @@ class ClosuresTest extends ParseTest {
   public function with_param() {
     $params= [new Parameter('a', null, null, false, false, null, null, null, self::LINE)];
     $this->assertParsed(
-      [new ClosureExpression(new Signature($params, null, null, self::LINE), null, [$this->returns], false, self::LINE)],
+      [new ClosureExpression(new Signature($params, null, false, self::LINE), null, [$this->returns], false, self::LINE)],
       'function($a) { return $a + 1; };'
     );
   }
@@ -40,7 +40,7 @@ class ClosuresTest extends ParseTest {
   #[Test]
   public function with_use_by_value() {
     $this->assertParsed(
-      [new ClosureExpression(new Signature([], null, null, self::LINE), ['$a', '$b'], [$this->returns], false, self::LINE)],
+      [new ClosureExpression(new Signature([], null, false, self::LINE), ['$a', '$b'], [$this->returns], false, self::LINE)],
       'function() use($a, $b) { return $a + 1; };'
     );
   }
@@ -48,7 +48,7 @@ class ClosuresTest extends ParseTest {
   #[Test]
   public function with_use_by_reference() {
     $this->assertParsed(
-      [new ClosureExpression(new Signature([], null, null, self::LINE), ['$a', '&$b'], [$this->returns], false, self::LINE)],
+      [new ClosureExpression(new Signature([], null, false, self::LINE), ['$a', '&$b'], [$this->returns], false, self::LINE)],
       'function() use($a, &$b) { return $a + 1; };'
     );
   }
@@ -56,7 +56,7 @@ class ClosuresTest extends ParseTest {
   #[Test]
   public function with_return_type() {
     $this->assertParsed(
-      [new ClosureExpression(new Signature([], new Type('int'), null, self::LINE), null, [$this->returns], false, self::LINE)],
+      [new ClosureExpression(new Signature([], new Type('int'), false, self::LINE), null, [$this->returns], false, self::LINE)],
       'function(): int { return $a + 1; };'
     );
   }
@@ -64,7 +64,7 @@ class ClosuresTest extends ParseTest {
   #[Test]
   public function with_nullable_return_type() {
     $this->assertParsed(
-      [new ClosureExpression(new Signature([], new Type('?int'), null, self::LINE), null, [$this->returns], false, self::LINE)],
+      [new ClosureExpression(new Signature([], new Type('?int'), false, self::LINE), null, [$this->returns], false, self::LINE)],
       'function(): ?int { return $a + 1; };'
     );
   }
@@ -72,7 +72,7 @@ class ClosuresTest extends ParseTest {
   #[Test]
   public function static_function() {
     $this->assertParsed(
-      [new ClosureExpression(new Signature([], null, null, self::LINE), null, [$this->returns], true, self::LINE)],
+      [new ClosureExpression(new Signature([], null, false, self::LINE), null, [$this->returns], true, self::LINE)],
       'static function() { return $a + 1; };'
     );
   }

--- a/src/test/php/lang/ast/unittest/parse/CommentTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/CommentTest.class.php
@@ -146,7 +146,7 @@ class CommentTest extends ParseTest {
   #[Test]
   public function apidoc_comment_attached_to_next_method() {
     $class= new ClassDeclaration([], new IsValue('\\T'), null, [], [], null, null, 2);
-    $class->declare(new Method(['public'], '__construct', new Signature([], null, null, 4), [], null, new Comment('/** @api */', 3), 4));
+    $class->declare(new Method(['public'], '__construct', new Signature([], null, false, 4), [], null, new Comment('/** @api */', 3), 4));
 
     $this->assertParsed([$class], '
       class T {

--- a/src/test/php/lang/ast/unittest/parse/FunctionsTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/FunctionsTest.class.php
@@ -36,8 +36,16 @@ class FunctionsTest extends ParseTest {
   #[Test]
   public function empty_function_without_parameters() {
     $this->assertParsed(
-      [new FunctionDeclaration('a', new Signature([], null, null, self::LINE), [], self::LINE)],
+      [new FunctionDeclaration('a', new Signature([], null, false, self::LINE), [], self::LINE)],
       'function a() { }'
+    );
+  }
+
+  #[Test]
+  public function returning_by_reference() {
+    $this->assertParsed(
+      [new FunctionDeclaration('a', new Signature([], null, true, self::LINE), [], self::LINE)],
+      'function &a() { }'
     );
   }
 
@@ -45,8 +53,8 @@ class FunctionsTest extends ParseTest {
   public function two_functions() {
     $this->assertParsed(
       [
-        new FunctionDeclaration('a', new Signature([], null, null, self::LINE), [], self::LINE),
-        new FunctionDeclaration('b', new Signature([], null, null, self::LINE), [], self::LINE)
+        new FunctionDeclaration('a', new Signature([], null, false, self::LINE), [], self::LINE),
+        new FunctionDeclaration('b', new Signature([], null, false, self::LINE), [], self::LINE)
       ],
       'function a() { } function b() { }'
     );
@@ -56,7 +64,7 @@ class FunctionsTest extends ParseTest {
   public function with_parameter($name) {
     $params= [new Parameter($name, null, null, false, false, null, null, null, self::LINE)];
     $this->assertParsed(
-      [new FunctionDeclaration('a', new Signature($params, null, null, self::LINE), [], self::LINE)],
+      [new FunctionDeclaration('a', new Signature($params, null, false, self::LINE), [], self::LINE)],
       'function a($'.$name.') { }'
     );
   }
@@ -65,7 +73,7 @@ class FunctionsTest extends ParseTest {
   public function with_reference_parameter() {
     $params= [new Parameter('param', null, null, true, false, null, null, null, self::LINE)];
     $this->assertParsed(
-      [new FunctionDeclaration('a', new Signature($params, null, null, self::LINE), [], self::LINE)],
+      [new FunctionDeclaration('a', new Signature($params, null, false, self::LINE), [], self::LINE)],
       'function a(&$param) { }'
     );
   }
@@ -74,7 +82,7 @@ class FunctionsTest extends ParseTest {
   public function dangling_comma_in_parameter_lists() {
     $params= [new Parameter('param', null, null, false, false, null, null, null, self::LINE)];
     $this->assertParsed(
-      [new FunctionDeclaration('a', new Signature($params, null, null, self::LINE), [], self::LINE)],
+      [new FunctionDeclaration('a', new Signature($params, null, false, self::LINE), [], self::LINE)],
       'function a($param, ) { }'
     );
   }
@@ -83,7 +91,7 @@ class FunctionsTest extends ParseTest {
   public function with_typed_parameter($declaration, $expected) {
     $params= [new Parameter('param', $expected, null, false, false, null, null, null, self::LINE)];
     $this->assertParsed(
-      [new FunctionDeclaration('a', new Signature($params, null, null, self::LINE), [], self::LINE)],
+      [new FunctionDeclaration('a', new Signature($params, null, false, self::LINE), [], self::LINE)],
       'function a('.$declaration.' $param) { }'
     );
   }
@@ -92,7 +100,7 @@ class FunctionsTest extends ParseTest {
   public function with_nullable_typed_parameter() {
     $params= [new Parameter('param', new IsNullable(new IsLiteral('string')), null, false, false, null, null, null, self::LINE)];
     $this->assertParsed(
-      [new FunctionDeclaration('a', new Signature($params, null, null, self::LINE), [], self::LINE)],
+      [new FunctionDeclaration('a', new Signature($params, null, false, self::LINE), [], self::LINE)],
       'function a(?string $param) { }'
     );
   }
@@ -101,7 +109,7 @@ class FunctionsTest extends ParseTest {
   public function with_variadic_parameter() {
     $params= [new Parameter('param', null, null, false, true, null, null, null, self::LINE)];
     $this->assertParsed(
-      [new FunctionDeclaration('a', new Signature($params, null, null, self::LINE), [], self::LINE)],
+      [new FunctionDeclaration('a', new Signature($params, null, false, self::LINE), [], self::LINE)],
       'function a(... $param) { }'
     );
   }
@@ -110,7 +118,7 @@ class FunctionsTest extends ParseTest {
   public function with_optional_parameter() {
     $params= [new Parameter('param', null, new Literal('null', self::LINE), false, false, null, null, null, self::LINE)];
     $this->assertParsed(
-      [new FunctionDeclaration('a', new Signature($params, null, null, self::LINE), [], self::LINE)],
+      [new FunctionDeclaration('a', new Signature($params, null, false, self::LINE), [], self::LINE)],
       'function a($param= null) { }'
     );
   }
@@ -119,7 +127,7 @@ class FunctionsTest extends ParseTest {
   public function with_parameter_named_function() {
     $params= [new Parameter('function', null, null, false, false, null, null, null, self::LINE)];
     $this->assertParsed(
-      [new FunctionDeclaration('a', new Signature($params, null, null, self::LINE), [], self::LINE)],
+      [new FunctionDeclaration('a', new Signature($params, null, false, self::LINE), [], self::LINE)],
       'function a($function, ) { }'
     );
   }
@@ -128,7 +136,7 @@ class FunctionsTest extends ParseTest {
   public function with_typed_parameter_named_function() {
     $params= [new Parameter('function', new IsFunction([], new IsLiteral('void')), null, false, false, null, null, null, self::LINE)];
     $this->assertParsed(
-      [new FunctionDeclaration('a', new Signature($params, null, null, self::LINE), [], self::LINE)],
+      [new FunctionDeclaration('a', new Signature($params, null, false, self::LINE), [], self::LINE)],
       'function a((function(): void) $function) { }'
     );
   }
@@ -136,7 +144,7 @@ class FunctionsTest extends ParseTest {
   #[Test, Values(from: 'types')]
   public function with_return_type($declaration, $expected) {
     $this->assertParsed(
-      [new FunctionDeclaration('a', new Signature([], $expected, null, self::LINE), [], self::LINE)],
+      [new FunctionDeclaration('a', new Signature([], $expected, false, self::LINE), [], self::LINE)],
       'function a(): '.$declaration.' { }'
     );
   }
@@ -145,7 +153,7 @@ class FunctionsTest extends ParseTest {
   public function generator() {
     $yield= new YieldExpression(null, null, self::LINE);
     $this->assertParsed(
-      [new FunctionDeclaration('a', new Signature([], null, null, self::LINE), [$yield], self::LINE)],
+      [new FunctionDeclaration('a', new Signature([], null, false, self::LINE), [$yield], self::LINE)],
       'function a() { yield; }'
     );
   }
@@ -154,7 +162,7 @@ class FunctionsTest extends ParseTest {
   public function generator_with_value() {
     $yield= new YieldExpression(null, new Literal('1', self::LINE), self::LINE);
     $this->assertParsed(
-      [new FunctionDeclaration('a', new Signature([], null, null, self::LINE), [$yield], self::LINE)],
+      [new FunctionDeclaration('a', new Signature([], null, false, self::LINE), [$yield], self::LINE)],
       'function a() { yield 1; }'
     );
   }
@@ -163,7 +171,7 @@ class FunctionsTest extends ParseTest {
   public function generator_with_key_and_value() {
     $yield= new YieldExpression(new Literal('"number"', self::LINE), new Literal('1', self::LINE), self::LINE);
     $this->assertParsed(
-      [new FunctionDeclaration('a', new Signature([], null, null, self::LINE), [$yield], self::LINE)],
+      [new FunctionDeclaration('a', new Signature([], null, false, self::LINE), [$yield], self::LINE)],
       'function a() { yield "number" => 1; }'
     );
   }
@@ -172,7 +180,7 @@ class FunctionsTest extends ParseTest {
   public function generator_delegation() {
     $yield= new YieldFromExpression(new ArrayLiteral([], self::LINE), self::LINE);
     $this->assertParsed(
-      [new FunctionDeclaration('a', new Signature([], null, null, self::LINE), [$yield], self::LINE)],
+      [new FunctionDeclaration('a', new Signature([], null, false, self::LINE), [$yield], self::LINE)],
       'function a() { yield from []; }'
     );
   }
@@ -186,7 +194,7 @@ class FunctionsTest extends ParseTest {
       self::LINE
     );
     $this->assertParsed(
-      [new FunctionDeclaration('a', new Signature([], null, null, self::LINE), [$yield], self::LINE)],
+      [new FunctionDeclaration('a', new Signature([], null, false, self::LINE), [$yield], self::LINE)],
       'function a() { $value= yield; }'
     );
   }
@@ -200,7 +208,7 @@ class FunctionsTest extends ParseTest {
       self::LINE
     );
     $this->assertParsed(
-      [new FunctionDeclaration('a', new Signature([], null, null, self::LINE), [$yield], self::LINE)],
+      [new FunctionDeclaration('a', new Signature([], null, false, self::LINE), [$yield], self::LINE)],
       'function a() { $value= yield (1); }'
     );
   }
@@ -215,7 +223,7 @@ class FunctionsTest extends ParseTest {
       self::LINE
     );
     $this->assertParsed(
-      [new FunctionDeclaration('a', new Signature([], null, null, self::LINE), [$yield], self::LINE)],
+      [new FunctionDeclaration('a', new Signature([], null, false, self::LINE), [$yield], self::LINE)],
       'function a() { $value= (yield); }'
     );
   }
@@ -229,7 +237,7 @@ class FunctionsTest extends ParseTest {
       self::LINE
     );
     $this->assertParsed(
-      [new FunctionDeclaration('a', new Signature([], null, null, self::LINE), [$yield], self::LINE)],
+      [new FunctionDeclaration('a', new Signature([], null, false, self::LINE), [$yield], self::LINE)],
       $declaration
     );
   }
@@ -243,7 +251,7 @@ class FunctionsTest extends ParseTest {
       self::LINE
     );
     $this->assertParsed(
-      [new FunctionDeclaration('a', new Signature([], null, null, self::LINE), [$yield], self::LINE)],
+      [new FunctionDeclaration('a', new Signature([], null, false, self::LINE), [$yield], self::LINE)],
       $declaration
     );
   }

--- a/src/test/php/lang/ast/unittest/parse/LambdasTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/LambdasTest.class.php
@@ -15,7 +15,7 @@ class LambdasTest extends ParseTest {
   #[Test]
   public function short_closure() {
     $this->assertParsed(
-      [new LambdaExpression(new Signature([$this->parameter], null, null, self::LINE), $this->expression, false, self::LINE)],
+      [new LambdaExpression(new Signature([$this->parameter], null, false, self::LINE), $this->expression, false, self::LINE)],
       'fn($a) => $a + 1;'
     );
   }
@@ -23,7 +23,7 @@ class LambdasTest extends ParseTest {
   #[Test]
   public function static_closure() {
     $this->assertParsed(
-      [new LambdaExpression(new Signature([$this->parameter], null, null, self::LINE), $this->expression, true, self::LINE)],
+      [new LambdaExpression(new Signature([$this->parameter], null, false, self::LINE), $this->expression, true, self::LINE)],
       'static fn($a) => $a + 1;'
     );
   }
@@ -33,7 +33,7 @@ class LambdasTest extends ParseTest {
     $this->assertParsed(
       [new InvokeExpression(
         new Literal('execute', self::LINE),
-        [new LambdaExpression(new Signature([$this->parameter], null, null, self::LINE), $this->expression, false, self::LINE)],
+        [new LambdaExpression(new Signature([$this->parameter], null, false, self::LINE), $this->expression, false, self::LINE)],
         self::LINE
       )],
       'execute(fn($a) => $a + 1);'
@@ -44,7 +44,7 @@ class LambdasTest extends ParseTest {
   public function short_closure_with_block() {
     $this->assertParsed(
       [new LambdaExpression(
-        new Signature([$this->parameter], null, null, self::LINE),
+        new Signature([$this->parameter], null, false, self::LINE),
         new Block([new ReturnStatement($this->expression, self::LINE)], self::LINE),
         false,
         self::LINE

--- a/src/test/php/lang/ast/unittest/parse/MembersTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/MembersTest.class.php
@@ -55,7 +55,7 @@ class MembersTest extends ParseTest {
   #[Test]
   public function private_instance_method() {
     $class= new ClassDeclaration([], new IsValue('\\A'), null, [], [], null, null, self::LINE);
-    $class->declare(new Method(['private'], 'a', new Signature([], null, null, self::LINE), [], null, null, self::LINE));
+    $class->declare(new Method(['private'], 'a', new Signature([], null, false, self::LINE), [], null, null, self::LINE));
 
     $this->assertParsed([$class], 'class A { private function a() { } }');
   }
@@ -63,9 +63,17 @@ class MembersTest extends ParseTest {
   #[Test]
   public function private_static_method() {
     $class= new ClassDeclaration([], new IsValue('\\A'), null, [], [], null, null, self::LINE);
-    $class->declare(new Method(['private', 'static'], 'a', new Signature([], null, null, self::LINE), [], null, null, self::LINE));
+    $class->declare(new Method(['private', 'static'], 'a', new Signature([], null, false, self::LINE), [], null, null, self::LINE));
 
     $this->assertParsed([$class], 'class A { private static function a() { } }');
+  }
+
+  #[Test]
+  public function method_returning_reference() {
+    $class= new ClassDeclaration([], new IsValue('\\A'), null, [], [], null, null, self::LINE);
+    $class->declare(new Method(['private', 'static'], 'a', new Signature([], null, true, self::LINE), [], null, null, self::LINE));
+
+    $this->assertParsed([$class], 'class A { private static function &a() { } }');
   }
 
   #[Test]
@@ -97,7 +105,7 @@ class MembersTest extends ParseTest {
   public function method_with_typed_parameter($declaration, $expected) {
     $class= new ClassDeclaration([], new IsValue('\\A'), null, [], [], null, null, self::LINE);
     $params= [new Parameter('param', $expected, null, false, false, null, null, null, self::LINE)];
-    $class->declare(new Method(['public'], 'a', new Signature($params, null, null, self::LINE), [], null, null, self::LINE));
+    $class->declare(new Method(['public'], 'a', new Signature($params, null, false, self::LINE), [], null, null, self::LINE));
 
     $this->assertParsed([$class], 'class A { public function a('.$declaration.' $param) { } }');
   }
@@ -105,7 +113,7 @@ class MembersTest extends ParseTest {
   #[Test, Values(from: 'types')]
   public function method_with_return_type($declaration, $expected) {
     $class= new ClassDeclaration([], new IsValue('\\A'), null, [], [], null, null, self::LINE);
-    $class->declare(new Method(['public'], 'a', new Signature([], $expected, null, self::LINE), [], null, null, self::LINE));
+    $class->declare(new Method(['public'], 'a', new Signature([], $expected, false, self::LINE), [], null, null, self::LINE));
 
     $this->assertParsed([$class], 'class A { public function a(): '.$declaration.' { } }');
   }
@@ -114,7 +122,7 @@ class MembersTest extends ParseTest {
   public function method_with_annotation() {
     $annotations= new Annotations(['Test' => []], self::LINE);
     $class= new ClassDeclaration([], new IsValue('\\A'), null, [], [], null, null, self::LINE);
-    $class->declare(new Method(['public'], 'a', new Signature([], null, null, self::LINE), [], $annotations, null, self::LINE));
+    $class->declare(new Method(['public'], 'a', new Signature([], null, false, self::LINE), [], $annotations, null, self::LINE));
 
     $this->assertParsed([$class], 'class A { #[Test] public function a() { } }');
   }
@@ -123,7 +131,7 @@ class MembersTest extends ParseTest {
   public function method_with_annotations() {
     $annotations= new Annotations(['Test' => [], 'Ignore' => [new Literal('"Not implemented"', self::LINE)]], self::LINE);
     $class= new ClassDeclaration([], new IsValue('\\A'), null, [], [], null, null, self::LINE);
-    $class->declare(new Method(['public'], 'a', new Signature([], null, null, self::LINE), [], $annotations, null, self::LINE));
+    $class->declare(new Method(['public'], 'a', new Signature([], null, false, self::LINE), [], $annotations, null, self::LINE));
 
     $this->assertParsed([$class], 'class A { #[Test, Ignore("Not implemented")] public function a() { } }');
   }


### PR DESCRIPTION
## Syntax

See https://www.php.net/manual/en/language.references.return.php

```php
class Test {
  private $list= [];

  public function &all() { return $this->list; }
}

$t= new Test();
$list= &$t->all();
$list[]= 'Test'; // Modifies Test::$list
```

## Implementation

The `lang.ast.nodes.Signature` class had an unused property, which was always set to *null*. This property was renamed and recycled for this purpose, keeping BC as much as possible.