### PR TITLE
Remove holder property for members

### DIFF
--- a/src/main/php/lang/ast/nodes/Constant.class.php
+++ b/src/main/php/lang/ast/nodes/Constant.class.php
@@ -2,15 +2,13 @@
 
 class Constant extends Annotated implements Member {
   public $kind= 'const';
-  public $name, $modifiers, $expression, $type, $holder;
+  public $name, $modifiers, $expression, $type;
 
-  public function __construct($modifiers, $name, $type, $expression, $annotations= null, $comment= null, $line= -1, $holder= null) {
+  public function __construct($modifiers, $name, $type, $expression, $annotations= null, $comment= null, $line= -1) {
     $this->modifiers= $modifiers;
     $this->name= $name;
     $this->type= $type;
     $this->expression= $expression;
-    $this->holder= $holder;
-
     parent::__construct($annotations, $comment, $line);
   }
 

--- a/src/main/php/lang/ast/nodes/EnumCase.class.php
+++ b/src/main/php/lang/ast/nodes/EnumCase.class.php
@@ -2,13 +2,11 @@
 
 class EnumCase extends Annotated implements Member {
   public $kind= 'enumcase';
-  public $name, $expression, $holder;
+  public $name, $expression;
 
-  public function __construct($name, $expression, $annotations, $comment, $line= -1, $holder= null) {
+  public function __construct($name, $expression, $annotations, $comment, $line= -1) {
     $this->name= $name;
     $this->expression= $expression;
-    $this->holder= $holder;
-
     parent::__construct($annotations, $comment, $line);
   }
 

--- a/src/main/php/lang/ast/nodes/Method.class.php
+++ b/src/main/php/lang/ast/nodes/Method.class.php
@@ -2,15 +2,13 @@
 
 class Method extends Annotated implements Member {
   public $kind= 'method';
-  public $name, $modifiers, $signature, $body, $holder;
+  public $name, $modifiers, $signature, $body;
 
-  public function __construct($modifiers, $name, $signature, $body= null, $annotations= null, $comment= null, $line= -1, $holder= null) {
+  public function __construct($modifiers, $name, $signature, $body= null, $annotations= null, $comment= null, $line= -1) {
     $this->name= $name;
     $this->modifiers= $modifiers;
     $this->signature= $signature;
     $this->body= $body;
-    $this->holder= $holder;
-
     parent::__construct($annotations, $comment, $line);
   }
 

--- a/src/main/php/lang/ast/nodes/Property.class.php
+++ b/src/main/php/lang/ast/nodes/Property.class.php
@@ -2,15 +2,13 @@
 
 class Property extends Annotated implements Member {
   public $kind= 'property';
-  public $name, $modifiers, $expression, $type, $holder;
+  public $name, $modifiers, $expression, $type;
 
-  public function __construct($modifiers, $name, $type, $expression= null, $annotations= null, $comment= null, $line= -1, $holder= null) {
+  public function __construct($modifiers, $name, $type, $expression= null, $annotations= null, $comment= null, $line= -1) {
     $this->modifiers= $modifiers;
     $this->name= $name;
     $this->type= $type;
     $this->expression= $expression;
-    $this->holder= $holder;
-
     parent::__construct($annotations, $comment, $line);
   }
 

--- a/src/main/php/lang/ast/nodes/TypeDeclaration.class.php
+++ b/src/main/php/lang/ast/nodes/TypeDeclaration.class.php
@@ -9,12 +9,7 @@ abstract class TypeDeclaration extends Annotated {
   public function __construct($modifiers, $name, $body= [], $annotations= null, $comment= null, $line= -1) {
     $this->modifiers= $modifiers;
     $this->name= $name;
-    $this->body= [];
-    foreach ($body as $lookup => $node) {
-      $node->holder= $this->name;
-      $this->body[$lookup]= $node;
-    }
-
+    $this->body= $body;
     parent::__construct($annotations, $comment, $line);
   }
 
@@ -71,7 +66,6 @@ abstract class TypeDeclaration extends Annotated {
     $lookup= $member->lookup();
     if (isset($this->body[$lookup])) return false;
 
-    $member->holder= $this->name;
     $this->body[$lookup]= $member;
     return true;
   }
@@ -86,7 +80,6 @@ abstract class TypeDeclaration extends Annotated {
     $lookup= $member->lookup();
     $overwritten= isset($this->body[$lookup]);
 
-    $member->holder= $this->name;
     $this->body[$lookup]= $member;
     return $overwritten;
   }

--- a/src/main/php/lang/ast/syntax/PHP.class.php
+++ b/src/main/php/lang/ast/syntax/PHP.class.php
@@ -887,7 +887,7 @@ class PHP extends Language {
 
       $decl= new InterfaceDeclaration([], $name, $parents, [], null, $comment, $token->line);
       $parse->expecting('{', 'interface');
-      $decl->body= $this->typeBody($parse, $decl->name);
+      $decl->body= $this->typeBody($parse);
       $parse->expecting('}', 'interface');
 
       return $decl;
@@ -900,7 +900,7 @@ class PHP extends Language {
 
       $decl= new TraitDeclaration([], $name, [], null, $comment, $token->line);
       $parse->expecting('{', 'trait');
-      $decl->body= $this->typeBody($parse, $decl->name);
+      $decl->body= $this->typeBody($parse);
       $parse->expecting('}', 'trait');
 
       return $decl;
@@ -938,7 +938,7 @@ class PHP extends Language {
 
       $decl= new EnumDeclaration([], $name, $base, $implements, [], null, $comment, $token->line);
       $parse->expecting('{', 'enum');
-      $decl->body= $this->typeBody($parse, $decl->name);
+      $decl->body= $this->typeBody($parse);
       $parse->expecting('}', 'enum');
 
       return $decl;
@@ -1546,7 +1546,7 @@ class PHP extends Language {
 
     $decl= new ClassDeclaration($modifiers, $name, $parent, $implements, [], null, $comment, $line);
     $parse->expecting('{', 'class');
-    $decl->body= $this->typeBody($parse, $decl->name);
+    $decl->body= $this->typeBody($parse);
     $parse->expecting('}', 'class');
 
     return $decl;

--- a/src/main/php/lang/ast/syntax/PHP.class.php
+++ b/src/main/php/lang/ast/syntax/PHP.class.php
@@ -944,7 +944,7 @@ class PHP extends Language {
       return $decl;
     });
 
-    $this->body('case', function($parse, &$body, $meta, $modifiers, $holder) {
+    $this->body('case', function($parse, &$body, $meta, $modifiers) {
       $comment= $parse->comment;
       $parse->comment= null;
 
@@ -961,13 +961,13 @@ class PHP extends Language {
           $expr= null;
         }
 
-        $body[$name]= new EnumCase($name, $expr, $meta[DETAIL_ANNOTATIONS] ?? null, $comment, $line, $holder);
+        $body[$name]= new EnumCase($name, $expr, $meta[DETAIL_ANNOTATIONS] ?? null, $comment, $line);
       } while (',' === $parse->token->value && true | $parse->forward());
 
       $parse->expecting(';', 'case');
     });
 
-    $this->body('use', function($parse, &$body, $meta, $modifiers, $holder) {
+    $this->body('use', function($parse, &$body, $meta, $modifiers) {
       $line= $parse->token->line;
 
       $parse->forward();
@@ -1009,7 +1009,7 @@ class PHP extends Language {
       $body[]= new UseExpression($types, $aliases, $line);
     });
 
-    $this->body('const', function($parse, &$body, $meta, $modifiers, $holder) {
+    $this->body('const', function($parse, &$body, $meta, $modifiers) {
       $comment= $parse->comment;
       $parse->comment= null;
       $parse->forward();
@@ -1046,8 +1046,7 @@ class PHP extends Language {
           $this->expression($parse, 0),
           $meta[DETAIL_ANNOTATIONS] ?? null,
           $comment,
-          $line,
-          $holder
+          $line
         );
         if (',' === $parse->token->value) {
           $parse->forward();
@@ -1056,11 +1055,11 @@ class PHP extends Language {
       $parse->expecting(';', 'constant declaration');
     });
 
-    $this->body('$', function($parse, &$body, $meta, $modifiers, $holder) {
-      $this->properties($parse, $body, $meta, $modifiers, null, $holder);
+    $this->body('$', function($parse, &$body, $meta, $modifiers) {
+      $this->properties($parse, $body, $meta, $modifiers, null);
     });
 
-    $this->body('function', function($parse, &$body, $meta, $modifiers, $holder) {
+    $this->body('function', function($parse, &$body, $meta, $modifiers) {
       $comment= $parse->comment;
       $parse->comment= null;
       $line= $parse->token->line;
@@ -1101,8 +1100,7 @@ class PHP extends Language {
         $statements,
         $meta[DETAIL_ANNOTATIONS] ?? null,
         $comment,
-        $line,
-        $holder
+        $line
       );
     });
   }
@@ -1292,7 +1290,7 @@ class PHP extends Language {
     return isset($literal[$type]) ? new IsLiteral($type) : new IsValue($type);
   }
 
-  private function properties($parse, &$body, $meta, $modifiers, $type, $holder) {
+  private function properties($parse, &$body, $meta, $modifiers, $type) {
     $comment= $parse->comment;
     $parse->comment= null;
     $annotations= $meta[DETAIL_ANNOTATIONS] ?? null;
@@ -1319,7 +1317,7 @@ class PHP extends Language {
       } else {
         $expr= null;
       }
-      $body[$lookup]= new Property($modifiers, $name, $type, $expr, $annotations, $comment, $line, $holder);
+      $body[$lookup]= new Property($modifiers, $name, $type, $expr, $annotations, $comment, $line);
 
       if (',' === $parse->token->value) {
         $parse->forward();
@@ -1423,7 +1421,7 @@ class PHP extends Language {
     $this->body[$id]= $func->bindTo($this, static::class);
   }
 
-  public function typeBody($parse, $holder) {
+  public function typeBody($parse) {
     static $modifier= [
       'private'   => true,
       'protected' => true,
@@ -1442,14 +1440,14 @@ class PHP extends Language {
         $modifiers[]= $parse->token->value;
         $parse->forward();
       } else if ($f= $this->body[$parse->token->value] ?? $this->body['@'.$parse->token->kind] ?? null) {
-        $f($parse, $body, $meta, $modifiers, $holder);
+        $f($parse, $body, $meta, $modifiers);
         $modifiers= [];
         $meta= [];
       } else if ('#[' === $parse->token->value) {
         $parse->forward();
         $meta[DETAIL_ANNOTATIONS]= $this->annotations($parse, 'member annotations');
       } else if ($type= $this->type($parse)) {
-        $this->properties($parse, $body, $meta, $modifiers, $type, $holder);
+        $this->properties($parse, $body, $meta, $modifiers, $type);
         $modifiers= [];
         $meta= [];
       } else {


### PR DESCRIPTION
Unused by compiler and other tools. Inside the compiler, the scope contains a reference to the current type's complete AST instead of just a name.