### PR TITLE
Implement generic method syntax

### DIFF
--- a/src/main/php/lang/ast/nodes/Generic.class.php
+++ b/src/main/php/lang/ast/nodes/Generic.class.php
@@ -1,0 +1,12 @@
+<?php namespace lang\ast\nodes;
+
+class Generic extends Literal {
+  public $kind= 'generic';
+  public $expression, $components;
+
+  public function __construct($expression, $components, $line= -1) {
+    $this->expression= $expression;
+    $this->components= $components;
+    $this->line= $line;
+  }
+}

--- a/src/main/php/lang/ast/nodes/Signature.class.php
+++ b/src/main/php/lang/ast/nodes/Signature.class.php
@@ -6,6 +6,7 @@ use lang\ast\Node;
 class Signature extends Node {
   public $kind= 'signature';
   public $parameters, $returns, $byref;
+  public $generic= null;
 
   public function __construct($parameters= [], $returns= null, $byref= false, $line= -1) {
     $this->parameters= $parameters;

--- a/src/test/php/lang/ast/unittest/parse/MembersTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/MembersTest.class.php
@@ -137,6 +137,17 @@ class MembersTest extends ParseTest {
   }
 
   #[Test]
+  public function generic_method() {
+    $signature= new Signature([], null, false, self::LINE);
+    $signature->generic= [new IsValue('T')];
+
+    $class= new ClassDeclaration([], new IsValue('\\A'), null, [], [], null, null, self::LINE);
+    $class->declare(new Method(['public'], 'a', $signature, [], null, null, self::LINE));
+
+    $this->assertParsed([$class], 'class A { public function a<T>() { } }');
+  }
+
+  #[Test]
   public function instance_property_access() {
     $this->assertParsed(
       [new InstanceExpression(new Variable('a', self::LINE), new Literal('member', self::LINE), self::LINE)],

--- a/src/test/php/lang/ast/unittest/parse/OperatorTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/OperatorTest.class.php
@@ -332,4 +332,42 @@ class OperatorTest extends ParseTest {
       ';; $a= 1 ;;; $b= 2;'
     );
   }
+
+  #[Test]
+  public function member_smaller_than_generic_call_ambiguity() {
+    $this->assertParsed(
+      [new BinaryExpression(
+        new InstanceExpression(new Variable('this', self::LINE), new Literal('test', self::LINE), self::LINE),
+        '<',
+        new Literal('THRESHOLD', self::LINE),
+        self::LINE
+      )],
+      '$this->test < THRESHOLD;'
+    );
+  }
+
+  #[Test]
+  public function arguments_with_constants_and_smaller_greater_generic_ambiguity() {
+    $this->assertParsed(
+      [new InvokeExpression(
+        new Literal('test', self::LINE),
+        [
+          new BinaryExpression(
+            new InstanceExpression(new Variable('this', self::LINE), new Literal('test', self::LINE), self::LINE),
+            '<',
+            new Literal('THRESHOLD', self::LINE),
+            self::LINE
+          ),
+          new BinaryExpression(
+            new Literal('THRESHOLD', self::LINE),
+            '>',
+            new Literal('1', self::LINE),
+            self::LINE
+          )
+        ],
+        self::LINE
+      )],
+      'test($this->test < THRESHOLD, THRESHOLD > 1);'
+    );
+  }
 }


### PR DESCRIPTION
```php
class Arrays {

  public static function reversed<T>(array<T> $elements) {
    // TBI
  }
}

$reversed= Arrays::reversed<string>(['A', 'B', 'C']);
```