### PR TITLE
Record starting line numbers for multi-line nodes

### DIFF
--- a/src/main/php/lang/ast/Language.class.php
+++ b/src/main/php/lang/ast/Language.class.php
@@ -47,21 +47,21 @@ class Language {
   public function assignment($id) {
     $infix= $this->symbol($id, 10);
     $infix->led= function($parse, $token, $left) use($id) {
-      return new Assignment($left, $id, $this->expression($parse, 9), $token->line);
+      return new Assignment($left, $id, $this->expression($parse, 9), $left->line);
     };
   }
 
   public function infix($id, $bp, $led= null) {
     $infix= $this->symbol($id, $bp);
     $infix->led= $led ? $led->bindTo($this, static::class) : function($parse, $token, $left) use($id, $bp) {
-      return new BinaryExpression($left, $id, $this->expression($parse, $bp), $token->line);
+      return new BinaryExpression($left, $id, $this->expression($parse, $bp), $left->line);
     };
   }
 
   public function infixr($id, $bp, $led= null) {
     $infix= $this->symbol($id, $bp);
     $infix->led= $led ? $led->bindTo($this, static::class) : function($parse, $token, $left) use($id, $bp) {
-      return new BinaryExpression($left, $id, $this->expression($parse, $bp - 1), $token->line);
+      return new BinaryExpression($left, $id, $this->expression($parse, $bp - 1), $left->line);
     };
   }
 
@@ -76,7 +76,7 @@ class Language {
   public function suffix($id, $bp, $led= null) {
     $suffix= $this->symbol($id, $bp);
     $suffix->led= $led ? $led->bindTo($this, static::class) : function($parse, $token, $left) use($id) {
-      $expr= new UnaryExpression('suffix', $left, $id, $token->line);
+      $expr= new UnaryExpression('suffix', $left, $id, $left->line);
       return $expr;
     };
   }

--- a/src/main/php/lang/ast/syntax/PHP.class.php
+++ b/src/main/php/lang/ast/syntax/PHP.class.php
@@ -128,18 +128,18 @@ class PHP extends Language {
     $this->infix('instanceof', 110, function($parse, $token, $left) {
       $type= $this->expression($parse, 110);
       if ($type instanceof Literal) {
-        return new InstanceOfExpression($left, $parse->scope->resolve($type->expression), $token->line);
+        return new InstanceOfExpression($left, $parse->scope->resolve($type->expression), $left->line);
       } else {
-        return new InstanceOfExpression($left, $type, $token->line);
+        return new InstanceOfExpression($left, $type, $left->line);
       }
     });
 
     $this->infix('->', 100, function($parse, $token, $left) {
-      return new InstanceExpression($left, $this->member($parse), $token->line);
+      return new InstanceExpression($left, $this->member($parse), $left->line);
     });
 
     $this->infix('?->', 100, function($parse, $node, $left) {
-      $value= new InstanceExpression($left, $this->member($parse), $node->line);
+      $value= new InstanceExpression($left, $this->member($parse), $left->line);
       $value->kind= 'nullsafeinstance';
       return $value;
     });
@@ -158,7 +158,7 @@ class PHP extends Language {
           $parse->forward();
           if (')' === $parse->token->value) {
             $parse->forward();
-            return new CallableExpression(new ScopeExpression($scope, $expr, $token->line), $token->line);
+            return new CallableExpression(new ScopeExpression($scope, $expr, $token->line), $left->line);
           }
 
           array_unshift($parse->queue, $parse->token);
@@ -170,7 +170,7 @@ class PHP extends Language {
         $expr= new InvokeExpression($expr, $arguments, $token->line);
       }
 
-      return new ScopeExpression($scope, $expr, $token->line);
+      return new ScopeExpression($scope, $expr, $left->line);
     });
 
     $this->infix('(', 100, function($parse, $token, $left) {
@@ -182,7 +182,7 @@ class PHP extends Language {
         $parse->forward();
         if (')' === $parse->token->value) {
           $parse->forward();
-          return new CallableExpression($left, $token->line);
+          return new CallableExpression($left, $left->line);
         }
 
         array_unshift($parse->queue, $parse->token);
@@ -191,7 +191,7 @@ class PHP extends Language {
 
       $arguments= $this->arguments($parse);
       $parse->expecting(')', 'invoke expression');
-      return new InvokeExpression($left, $arguments, $token->line);
+      return new InvokeExpression($left, $arguments, $left->line);
     });
 
     $this->infix('[', 100, function($parse, $token, $left) {
@@ -203,14 +203,14 @@ class PHP extends Language {
         $parse->expecting(']', 'offset access');
       }
 
-      return new OffsetExpression($left, $expr, $token->line);
+      return new OffsetExpression($left, $expr, $left->line);
     });
 
     $this->infix('?', 80, function($parse, $token, $left) {
       $when= $this->expression($parse, 0);
       $parse->expecting(':', 'ternary');
       $else= $this->expression($parse, 0);
-      return new TernaryExpression($left, $when, $else, $token->line);
+      return new TernaryExpression($left, $when, $else, $left->line);
     });
 
     $this->prefix('@', 90);

--- a/src/test/php/lang/ast/unittest/parse/InvokeTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/InvokeTest.class.php
@@ -106,4 +106,30 @@ class InvokeTest extends ParseTest {
       'new T(...);'
     );
   }
+
+  #[Test]
+  public function chained_invocation_spanning_multiple_lines() {
+    $expr= new InvokeExpression(
+      new InstanceExpression(
+        new InvokeExpression(
+          new InstanceExpression(
+            new Variable('this', self::LINE),
+            new Literal('test', self::LINE + 1),
+            self::LINE + 1
+          ),
+          [],
+          self::LINE + 1
+        ),
+        new Literal('chained', self::LINE + 2),
+        self::LINE + 2
+      ),
+      [],
+      self::LINE + 2
+    );
+
+    $this->assertParsed([$expr], '$this
+      ->test()
+      ->chained()
+    ;');
+  }
 }

--- a/src/test/php/lang/ast/unittest/parse/InvokeTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/InvokeTest.class.php
@@ -115,16 +115,16 @@ class InvokeTest extends ParseTest {
           new InstanceExpression(
             new Variable('this', self::LINE),
             new Literal('test', self::LINE + 1),
-            self::LINE + 1
+            self::LINE
           ),
           [],
-          self::LINE + 1
+          self::LINE
         ),
         new Literal('chained', self::LINE + 2),
-        self::LINE + 2
+        self::LINE
       ),
       [],
-      self::LINE + 2
+      self::LINE
     );
 
     $this->assertParsed([$expr], '$this


### PR DESCRIPTION
Given the following code:

```php
1 | Sequence::of($enumerable)
2 |  ->map(fn($a) => $a * 2)
3 |  ->filter(fn($a) => $a % 2)
4 |  ->each(fn($a) => echo $a)
5 | ;
```

Previously, the `Sequence::of()` invocation would be recorded with *line = 5*. After this PR is merged, this changes to *line = 1*. This ensures the emitted code doesn't all end up being written to line 5, as the cursor is positioned to this line as soon as the first invocation is encountered.