### PR TITLE
Syntactic support for type aliases

### DIFF
--- a/src/main/php/lang/ast/syntax/PHP.class.php
+++ b/src/main/php/lang/ast/syntax/PHP.class.php
@@ -603,6 +603,10 @@ class PHP extends Language {
           $names[$import]= $parse->token->value;
           $parse->scope->import($import, $parse->token->value);
           $parse->forward();
+        } else if ('=' === $parse->token->value) {
+          $parse->forward();
+          $type= 'type';
+          $names[$import]= $this->type($parse, false);
         } else {
           $names[$import]= null;
           $parse->scope->import($import);

--- a/src/test/php/lang/ast/unittest/parse/NamespacesTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/NamespacesTest.class.php
@@ -1,6 +1,7 @@
 <?php namespace lang\ast\unittest\parse;
 
 use lang\ast\nodes\{NamespaceDeclaration, UseStatement};
+use lang\ast\types\{IsLiteral, IsUnion};
 use test\{Assert, Test};
 
 class NamespacesTest extends ParseTest {
@@ -98,6 +99,14 @@ class NamespacesTest extends ParseTest {
     $this->assertParsed(
       [new UseStatement('const', ['MODIFIER_STATIC' => null], self::LINE)],
       'use const MODIFIER_STATIC;'
+    );
+  }
+
+  #[Test]
+  public function use_type() {
+    $this->assertParsed(
+      [new UseStatement('type', ['Name' => new IsUnion([new IsLiteral('string'), new IsLiteral('null')])], self::LINE)],
+      'use Name = string|null;'
     );
   }
 }


### PR DESCRIPTION
In a nutshell:

```php
use numeric = string|int;

function multiply(numeric $a, numeric $b) {
  return bcmul($a, $b);
}
```

See also:

* https://externals.io/message/121466
* https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/proposals/csharp-12.0/using-alias-types