### PR TITLE
Add syntactic support for `T<string>::class`

### DIFF
--- a/src/main/php/lang/ast/syntax/PHP.class.php
+++ b/src/main/php/lang/ast/syntax/PHP.class.php
@@ -264,7 +264,7 @@ class PHP extends Language {
         $parse->forward();
         $skipped[]= $parse->token;
       }
-      $parse->queue= $parse->queue ? array_merge($skipped, $parse->queue) : $skipped;
+      $parse->queue= $parse->queue ? [...$skipped, ...$parse->queue] : $skipped;
 
       if ($cast && ('operator' !== $parse->token->kind || '(' === $parse->token->value || '[' === $parse->token->value)) {
         $parse->forward();
@@ -507,7 +507,7 @@ class PHP extends Language {
           }
         }
 
-        $parse->queue= $parse->queue ? array_merge($skipped, $parse->queue) : $skipped;
+        $parse->queue= $parse->queue ? [...$skipped, ...$parse->queue] : $skipped;
         if ($generic) {
           $parse->token= $token;
           return $this->type($parse, false);

--- a/src/test/php/lang/ast/unittest/parse/MembersTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/MembersTest.class.php
@@ -19,7 +19,7 @@ use lang\ast\nodes\{
   Variable,
   Parameter
 };
-use lang\ast\types\{IsFunction, IsLiteral, IsNullable, IsUnion, IsValue};
+use lang\ast\types\{IsFunction, IsLiteral, IsNullable, IsUnion, IsValue, IsGeneric};
 use test\{Assert, Test, Values};
 
 class MembersTest extends ParseTest {
@@ -294,6 +294,14 @@ class MembersTest extends ParseTest {
     $this->assertParsed(
       [new ScopeExpression('\\A', new Literal('class', self::LINE), self::LINE)],
       'A::class;'
+    );
+  }
+
+  #[Test]
+  public function generic_class_resolution() {
+    $this->assertParsed(
+      [new ScopeExpression(new IsGeneric(new IsValue('\\A'), [new IsValue('\\T')]), new Literal('class', self::LINE), self::LINE)],
+      'A<T>::class;'
     );
   }
 

--- a/src/test/php/lang/ast/unittest/parse/OperatorTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/OperatorTest.class.php
@@ -332,4 +332,17 @@ class OperatorTest extends ParseTest {
       ';; $a= 1 ;;; $b= 2;'
     );
   }
+
+  #[Test]
+  public function const_less_than_const() {
+    $this->assertParsed(
+      [new BinaryExpression(
+        new Literal('a', self::LINE),
+        '<',
+        new Literal('b', self::LINE),
+        self::LINE
+      )],
+      'a < b;'
+    );
+  }
 }

--- a/src/test/php/lang/ast/unittest/parse/OperatorTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/OperatorTest.class.php
@@ -18,7 +18,7 @@ use lang\ast\nodes\{
   UnaryExpression,
   Variable
 };
-use lang\ast\types\{IsExpression, IsValue};
+use lang\ast\types\{IsExpression, IsGeneric, IsValue};
 use test\{Assert, Test, Values};
 
 class OperatorTest extends ParseTest {
@@ -280,6 +280,18 @@ class OperatorTest extends ParseTest {
         self::LINE
       )],
       '!$this instanceof self;'
+    );
+  }
+
+  #[Test]
+  public function instanceof_generic() {
+    $this->assertParsed(
+      [new InstanceOfExpression(
+        new Variable('this', self::LINE),
+        new IsGeneric(new IsValue('self'), [new IsValue('T')]),
+        self::LINE
+      )],
+      '$this instanceof self<T>;'
     );
   }
 


### PR DESCRIPTION
Example (when using https://github.com/xp-lang/xp-generics):

```php
$name= T<string>::class; // "T\xb7\xb7\xfestring"
```