### PR TITLE
Add syntactic support for asymmetric visibility

### DIFF
--- a/src/main/php/lang/ast/syntax/PHP.class.php
+++ b/src/main/php/lang/ast/syntax/PHP.class.php
@@ -1476,6 +1476,19 @@ class PHP extends Language {
     return $annotations;
   }
 
+  private function modifier($parse) {
+    $token= $parse->token->value;
+    $parse->forward();
+
+    if ('(' === $parse->token->value) {
+      $parse->expecting('(', 'modifiers');
+      $token.= '('.$parse->token->value.')';
+      $parse->forward();
+      $parse->expecting(')', 'modifiers');
+    }
+    return $token;
+  }
+
   private function parameters($parse) {
     static $promotion= [
       'private'   => true,
@@ -1497,17 +1510,7 @@ class PHP extends Language {
       if ('name' === $parse->token->kind && isset($promotion[$parse->token->value])) {
         $promote= [];
         do {
-          $token= $parse->token->value;
-          $parse->forward();
-
-          if ('(' === $parse->token->value) {
-            $parse->expecting('(', 'modifiers');
-            $token.= '('.$parse->token->value.')';
-            $parse->forward();
-            $parse->expecting(')', 'modifiers');
-          }
-
-          $promote[]= $token;
+          $promote[]= $this->modifier($parse);
         } while ('name' === $parse->token->kind && isset($promotion[$parse->token->value]));
       } else {
         $promote= null;
@@ -1577,17 +1580,7 @@ class PHP extends Language {
     $meta= [];
     while ('}' !== $parse->token->value) {
       if (isset($modifier[$parse->token->value])) {
-        $token= $parse->token->value;
-        $parse->forward();
-
-        if ('(' === $parse->token->value) {
-          $parse->expecting('(', 'modifiers');
-          $token.= '('.$parse->token->value.')';
-          $parse->forward();
-          $parse->expecting(')', 'modifiers');
-        }
-
-        $modifiers[]= $token;
+        $modifiers[]= $this->modifier($parse);
       } else if ($f= $this->body[$parse->token->value] ?? $this->body['@'.$parse->token->kind] ?? null) {
         $f($parse, $body, $meta, $modifiers);
         $modifiers= [];

--- a/src/main/php/lang/ast/syntax/PHP.class.php
+++ b/src/main/php/lang/ast/syntax/PHP.class.php
@@ -1477,6 +1477,8 @@ class PHP extends Language {
   }
 
   private function modifier($parse) {
+    static $hooks= ['set' => true];
+
     $modifier= $parse->token->value;
     $parse->forward();
 
@@ -1484,16 +1486,14 @@ class PHP extends Language {
       $token= $parse->token;
       $parse->expecting('(', 'modifiers');
 
-      // Disambiguate function types from `private(set)`
-      if ('function' === $parse->token->value) {
+      if (isset($hooks[$parse->token->value])) {
+        $modifier.= '('.$parse->token->value.')';
+        $parse->forward();
+        $parse->expecting(')', 'modifiers');
+      } else {
         array_unshift($parse->queue, $parse->token);
         $parse->token= $token;
-        return $modifier;
       }
-
-      $modifier.= '('.$parse->token->value.')';
-      $parse->forward();
-      $parse->expecting(')', 'modifiers');
     }
     return $modifier;
   }

--- a/src/main/php/lang/ast/syntax/PHP.class.php
+++ b/src/main/php/lang/ast/syntax/PHP.class.php
@@ -1566,8 +1566,17 @@ class PHP extends Language {
     $meta= [];
     while ('}' !== $parse->token->value) {
       if (isset($modifier[$parse->token->value])) {
-        $modifiers[]= $parse->token->value;
+        $token= $parse->token->value;
         $parse->forward();
+
+        if ('(' === $parse->token->value) {
+          $parse->expecting('(', 'modifiers');
+          $token.= '('.$parse->token->value.')';
+          $parse->forward();
+          $parse->expecting(')', 'modifiers');
+        }
+
+        $modifiers[]= $token;
       } else if ($f= $this->body[$parse->token->value] ?? $this->body['@'.$parse->token->kind] ?? null) {
         $f($parse, $body, $meta, $modifiers);
         $modifiers= [];

--- a/src/main/php/lang/ast/syntax/PHP.class.php
+++ b/src/main/php/lang/ast/syntax/PHP.class.php
@@ -1477,16 +1477,25 @@ class PHP extends Language {
   }
 
   private function modifier($parse) {
-    $token= $parse->token->value;
+    $modifier= $parse->token->value;
     $parse->forward();
 
     if ('(' === $parse->token->value) {
+      $token= $parse->token;
       $parse->expecting('(', 'modifiers');
-      $token.= '('.$parse->token->value.')';
+
+      // Disambiguate function types from `private(set)`
+      if ('function' === $parse->token->value) {
+        array_unshift($parse->queue, $parse->token);
+        $parse->token= $token;
+        return $modifier;
+      }
+
+      $modifier.= '('.$parse->token->value.')';
       $parse->forward();
       $parse->expecting(')', 'modifiers');
     }
-    return $token;
+    return $modifier;
   }
 
   private function parameters($parse) {

--- a/src/main/php/lang/ast/syntax/PHP.class.php
+++ b/src/main/php/lang/ast/syntax/PHP.class.php
@@ -1511,7 +1511,7 @@ class PHP extends Language {
         $promote= [];
         do {
           $promote[]= $this->modifier($parse);
-        } while ('name' === $parse->token->kind && isset($promotion[$parse->token->value]));
+        } while (isset($promotion[$parse->token->value]));
       } else {
         $promote= null;
       }

--- a/src/test/php/lang/ast/unittest/parse/MembersTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/MembersTest.class.php
@@ -380,4 +380,12 @@ class MembersTest extends ParseTest {
 
     $this->assertParsed([$class], 'class A { const int T = 1, S = 2, string I = "i"; }');
   }
+
+  #[Test]
+  public function asymmetric_property() {
+    $class= new ClassDeclaration([], new IsValue('\\A'), null, [], [], null, null, self::LINE);
+    $class->declare(new Property(['public', 'private(set)'], 'a', new Type('int'), null, null, null, self::LINE));
+
+    $this->assertParsed([$class], 'class A { public private(set) int $a; }');
+  }
 }

--- a/src/test/php/lang/ast/unittest/parse/MembersTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/MembersTest.class.php
@@ -388,4 +388,13 @@ class MembersTest extends ParseTest {
 
     $this->assertParsed([$class], 'class A { public private(set) int $a; }');
   }
+
+  #[Test]
+  public function asymmetric_property_as_constructor_argument() {
+    $params= [new Parameter('a', new IsLiteral('int'), null, false, false, ['private(set)'], null, null, self::LINE)];
+    $class= new ClassDeclaration([], new IsValue('\\A'), null, [], [], null, null, self::LINE);
+    $class->declare(new Method(['public'], '__construct', new Signature($params, null, false, self::LINE), [], null, null, self::LINE));
+
+    $this->assertParsed([$class], 'class A { public function __construct(private(set) int $a) { } }');
+  }
 }


### PR DESCRIPTION
This pull request adds syntactic support for asymmetric visibility using `(set)` specifiers on property modifiers. The modifiers contain the string as declared, e.g. `"private(set)"` in the below example and need to be translated by the compiler!

## Example
Support in property declarations:

```php
class Person {
  public private(set) string $name= 'Test';
}
 
$person= new Person();
echo $person->name;       // OK
$person->name= 'Changed'; // Visibility error
```

Support in promoted constructor parameters:
```php
class Person {
  public function __construct(private(set) string $name) { }
}
```

See https://wiki.php.net/rfc/asymmetric-visibility-v2 and https://github.com/xp-framework/compiler/issues/182