### PR TITLE
Add suport for heredoc (and its nowdoc variant)

### DIFF
--- a/src/main/php/lang/ast/Tokens.class.php
+++ b/src/main/php/lang/ast/Tokens.class.php
@@ -179,6 +179,25 @@ class Tokens {
             continue;
           }
           null === $t || $offset-= strlen($t);
+        } else if ('<' === $token) {
+          $t= $next(self::DELIMITERS);
+          if ('<' === $t) {
+            $t= $next(self::DELIMITERS);
+            if ('<' === $t) {
+              $label= $next("\r\n");
+              $end= trim($label, '"\'');
+              $string= "<<<{$label}";
+              do {
+                $token= $next("\r\n");
+                if ("\n" === $token) $line++;
+              } while (strncmp($end, $token, strlen($end)) && $string.= $token);
+              $string.= $end;
+              yield new Token($language->symbol('(literal)'), 'heredoc', $string, $line);
+              $offset--;
+              continue;
+            }
+          }
+          $offset-= 2;
         }
 
         // Handle combined operators. First, ensure we have enough bytes in our buffer

--- a/src/test/php/lang/ast/unittest/parse/LiteralsTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/LiteralsTest.class.php
@@ -86,4 +86,17 @@ class LiteralsTest extends ParseTest {
     $pair= [new Literal('"key"', self::LINE), new Literal('"value"', self::LINE)];
     $this->assertParsed([new ArrayLiteral([$pair], self::LINE)], $declaration);
   }
+
+  #[Test, Values(['EOD', '"EOD"', "'EOD'"])]
+  public function heredoc($label) {
+    $nowdoc= (
+      "<<<{$label}\n".
+      "Line 1\n".
+      "Line 2\n".
+      "\n".
+      "Line 4\n".
+      "EOD"
+    );
+    $this->assertParsed([new Literal($nowdoc, self::LINE + 5)], $nowdoc.';');
+  }
 }


### PR DESCRIPTION
Example:

```php
$message= <<<'EOD'
This message spans
multiple lines
EOD;
```

See https://www.php.net/manual/en/language.types.string.php#language.types.string.syntax.heredoc