### PR TITLE
Add support for single-expression methods

### DIFF
--- a/src/main/php/lang/ast/syntax/PHP.class.php
+++ b/src/main/php/lang/ast/syntax/PHP.class.php
@@ -1130,6 +1130,10 @@ class PHP extends Language {
         $parse->forward();
         $statements= $this->statements($parse);
         $parse->expecting('}', 'method declaration');
+      } else if ('=>' === $parse->token->value) {  // Single expression
+        $parse->forward();
+        $statements= [new ReturnStatement($this->expression($parse, 0), $parse->token->line)];
+        $parse->expecting(';', 'method expression');
       } else if (';' === $parse->token->value) {   // Abstract or interface method
         $statements= null;
         $parse->expecting(';', 'method declaration');

--- a/src/test/php/lang/ast/unittest/parse/MembersTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/MembersTest.class.php
@@ -148,6 +148,15 @@ class MembersTest extends ParseTest {
   }
 
   #[Test]
+  public function single_expression_method() {
+    $expr= new ReturnStatement(new Literal('true', self::LINE), self::LINE);
+    $class= new ClassDeclaration([], new IsValue('\\A'), null, [], [], null, null, self::LINE);
+    $class->declare(new Method(['private'], 'a', new Signature([], null, false, self::LINE), [$expr], null, null, self::LINE));
+
+    $this->assertParsed([$class], 'class A { private function a() => true; }');
+  }
+
+  #[Test]
   public function property_with_get_and_set_hooks() {
     $class= new ClassDeclaration([], new IsValue('\\A'), null, [], [], null, null, self::LINE);
     $prop= new Property(['public'], 'a', null, null, null, null, self::LINE);


### PR DESCRIPTION
This PR adds syntactic support for single-expression methods

```php
class Person {
  public function __construct(private string $name) { }

  // Equivalent of public function name() { return $this->name; }
  public function name() => $this->name;
}
```

See:
* https://wiki.php.net/rfc/single-expression-functions
* https://github.com/xp-lang/php-compact-methods (same but uses `fn`)
* https://github.com/php/php-src/pull/17677