### PR TITLE
Implement logical AND and OR assignment operators (&&=, ||=)

### DIFF
--- a/src/main/php/lang/ast/syntax/PHP.class.php
+++ b/src/main/php/lang/ast/syntax/PHP.class.php
@@ -4,6 +4,7 @@ use lang\ast\nodes\{
   ArrayLiteral,
   Annotation,
   Annotations,
+  Assignment,
   Block,
   Braced,
   BreakStatement,
@@ -233,8 +234,15 @@ class PHP extends Language {
     $this->assignment('>>=');
     $this->assignment('<<=');
     $this->assignment('??=');
-    $this->assignment('&&=');
-    $this->assignment('||=');
+
+    // Logical AND and OR, not supported in PHP
+    foreach (['&&=', '||='] as $op) {
+      $this->symbol($op, 10)->led= function($parse, $token, $left) use($op) {
+        $assign= new Assignment($left, $op, $this->expression($parse, 9), $left->line);
+        $assign->kind= 'logicalassignment';
+        return $assign;
+      };
+    }
 
     // This is ambiguous:
     //

--- a/src/test/php/lang/ast/unittest/parse/OperatorTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/OperatorTest.class.php
@@ -64,12 +64,19 @@ class OperatorTest extends ParseTest {
     );
   }
 
-  #[Test, Values(['=', '+=', '-=', '*=', '/=', '%=', '.=', '**=', '&=', '|=', '^=', '>>=', '<<=', '??=', '&&=', '||='])]
+  #[Test, Values(['=', '+=', '-=', '*=', '/=', '%=', '.=', '**=', '&=', '|=', '^=', '>>=', '<<=', '??='])]
   public function assignment($operator) {
     $this->assertParsed(
       [new Assignment(new Variable('a', self::LINE), $operator, new Variable('b', self::LINE), self::LINE)],
       '$a '.$operator.' $b;'
     );
+  }
+
+  #[Test, Values(['&&=', '||='])]
+  public function logical_assignment($operator) {
+    $assignment= new Assignment(new Variable('a', self::LINE), $operator, new Variable('b', self::LINE), self::LINE);
+    $assignment->kind= 'logicalassignment';
+    $this->assertParsed([$assignment], '$a '.$operator.' $b;');
   }
 
   #[Test]


### PR DESCRIPTION
Implements feature suggested in xp-framework/compiler#133. These operators are both in JS and baseline available, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Logical_OR_assignment and https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Logical_AND_assignment