### PR TITLE
Refactor function scopes: Capturing and returning

### DIFF
--- a/src/main/php/lang/ast/nodes/Block.class.php
+++ b/src/main/php/lang/ast/nodes/Block.class.php
@@ -1,8 +1,9 @@
 <?php namespace lang\ast\nodes;
 
+use Traversable, IteratorAggregate;
 use lang\ast\Node;
 
-class Block extends Node {
+class Block extends Node implements IteratorAggregate {
   public $kind= 'block';
   public $statements;
 
@@ -13,4 +14,7 @@ class Block extends Node {
 
   /** @return iterable */
   public function children() { return $this->statements; }
+
+  /** Iteration support */
+  public function getIterator(): Traversable { yield from $this->statements; }
 }

--- a/src/main/php/lang/ast/nodes/ClosureExpression.class.php
+++ b/src/main/php/lang/ast/nodes/ClosureExpression.class.php
@@ -7,13 +7,11 @@ class ClosureExpression extends Annotated {
   public function __construct($signature, $use, $body, $static= false, $line= -1) {
     $this->signature= $signature;
     $this->use= $use;
-    $this->body= $body;
+    $this->body= is_array($body) ? new Block($body, $line) : $body;
     $this->static= $static;
     $this->line= $line;
   }
 
   /** @return iterable */
-  public function children() {
-    return is_array($this->body) ? $this->body : [&$this->body]; // Array = BC
-  }
+  public function children() { return [&$this->body]; }
 }

--- a/src/main/php/lang/ast/nodes/ClosureExpression.class.php
+++ b/src/main/php/lang/ast/nodes/ClosureExpression.class.php
@@ -13,5 +13,7 @@ class ClosureExpression extends Annotated {
   }
 
   /** @return iterable */
-  public function children() { return $this->body; }
+  public function children() {
+    return is_array($this->body) ? $this->body : [&$this->body]; // Array = BC
+  }
 }

--- a/src/main/php/lang/ast/nodes/FunctionDeclaration.class.php
+++ b/src/main/php/lang/ast/nodes/FunctionDeclaration.class.php
@@ -7,12 +7,10 @@ class FunctionDeclaration extends Annotated {
   public function __construct($name, $signature, $body, $line= -1) {
     $this->name= $name;
     $this->signature= $signature;
-    $this->body= $body;
+    $this->body= is_array($body) ? new Block($body, $line) : $body;
     $this->line= $line;
   }
 
   /** @return iterable */
-  public function children() {
-    return is_array($this->body) ? $this->body : [&$this->body]; // Array = BC
-  }
+  public function children() { return [&$this->body]; }
 }

--- a/src/main/php/lang/ast/nodes/FunctionDeclaration.class.php
+++ b/src/main/php/lang/ast/nodes/FunctionDeclaration.class.php
@@ -12,5 +12,7 @@ class FunctionDeclaration extends Annotated {
   }
 
   /** @return iterable */
-  public function children() { return $this->body; }
+  public function children() {
+    return is_array($this->body) ? $this->body : [&$this->body]; // Array = BC
+  }
 }

--- a/src/main/php/lang/ast/nodes/LambdaExpression.class.php
+++ b/src/main/php/lang/ast/nodes/LambdaExpression.class.php
@@ -6,13 +6,11 @@ class LambdaExpression extends Annotated {
 
   public function __construct($signature, $body, $static= false, $line= -1) {
     $this->signature= $signature;
-    $this->body= $body;
+    $this->body= is_array($body) ? new Block($body, $line) : $body;
     $this->static= $static;
     $this->line= $line;
   }
 
   /** @return iterable */
-  public function children() {
-    return is_array($this->body) ? $this->body : [&$this->body]; // Array = BC
-  }
+  public function children() { return [&$this->body]; }
 }

--- a/src/main/php/lang/ast/nodes/LambdaExpression.class.php
+++ b/src/main/php/lang/ast/nodes/LambdaExpression.class.php
@@ -13,6 +13,6 @@ class LambdaExpression extends Annotated {
 
   /** @return iterable */
   public function children() {
-    return is_array($this->body) ? $this->body : [&$this->body];
+    return is_array($this->body) ? $this->body : [&$this->body]; // Array = BC
   }
 }

--- a/src/main/php/lang/ast/nodes/Method.class.php
+++ b/src/main/php/lang/ast/nodes/Method.class.php
@@ -8,7 +8,7 @@ class Method extends Annotated implements Member {
     $this->name= $name;
     $this->modifiers= $modifiers;
     $this->signature= $signature;
-    $this->body= $body;
+    $this->body= is_array($body) ? new Block($body, $line) : $body;
     parent::__construct($annotations, $comment, $line);
   }
 
@@ -46,13 +46,5 @@ class Method extends Annotated implements Member {
   }
 
   /** @return iterable */
-  public function children() {
-    if (null === $this->body) {
-      return [];
-    } else if (is_array($this->body)) { // BC
-      return $this->body;
-    } else {
-      return [&$this->body];
-    }
-  }
+  public function children() { return null === $this->body ? [] : [&$this->body]; }
 }

--- a/src/main/php/lang/ast/nodes/Method.class.php
+++ b/src/main/php/lang/ast/nodes/Method.class.php
@@ -46,5 +46,13 @@ class Method extends Annotated implements Member {
   }
 
   /** @return iterable */
-  public function children() { return (array)$this->body; }
+  public function children() {
+    if (null === $this->body) {
+      return [];
+    } else if (is_array($this->body)) { // BC
+      return $this->body;
+    } else {
+      return [&$this->body];
+    }
+  }
 }

--- a/src/main/php/lang/ast/syntax/PHP.class.php
+++ b/src/main/php/lang/ast/syntax/PHP.class.php
@@ -307,12 +307,6 @@ class PHP extends Language {
       return new CloneExpression($arguments, $token->line);
     });
 
-    $this->prefix('{', 0, function($parse, $token) {
-      $statements= $this->statements($parse);
-      $parse->expecting('}', 'block');
-      return new Block($statements, $token->line);
-    });
-
     $this->prefix('[', 0, function($parse, $token) {
       return new ArrayLiteral($this->list($parse, ']', 'array literal'), $token->line);
     });
@@ -400,9 +394,8 @@ class PHP extends Language {
 
     $this->prefix('fn', 0, function($parse, $token) {
       $signature= $this->signature($parse);
-      $parse->expecting('=>', 'fn');
-
-      return new LambdaExpression($signature, $this->expression($parse, 0), false, $token->line);
+      $scope= $this->scope($parse, 'fn');
+      return new LambdaExpression($signature, $scope, false, $token->line);
     });
 
     $this->prefix('function', 0, function($parse, $token) {
@@ -435,8 +428,8 @@ class PHP extends Language {
       } else if ('fn' === $parse->token->value) {
         $parse->forward();
         $signature= $this->signature($parse);
-        $parse->expecting('=>', 'fn');
-        return new LambdaExpression($signature, $this->expression($parse, 0), true, $token->line);
+        $scope= $this->scope($parse, 'fn');
+        return new LambdaExpression($signature, $scope, true, $token->line);
       } else {
         return new Literal($token->value, $token->line);
       }
@@ -463,15 +456,14 @@ class PHP extends Language {
       while ('}' !== $parse->token->value) {
         if ('default' === $parse->token->value) {
           $parse->forward();
-          $parse->expecting('=>', 'match');
-          $default= $this->expression($parse, 0);
+          $default= $this->scope($parse, 'match');
         } else {
           $match= [];
           do {
             $match[]= $this->expression($parse, 0);
           } while (',' === $parse->token->value && $parse->forward() | true);
-          $parse->expecting('=>', 'match');
-          $cases[]= new MatchCondition($match, $this->expression($parse, 0), $parse->token->line);
+
+          $cases[]= new MatchCondition($match, $this->scope($parse, 'match'), $parse->token->line);
         }
 
         if (',' === $parse->token->value) {
@@ -533,6 +525,12 @@ class PHP extends Language {
       return new Literal($token->value, $token->line);
     });
 
+    // Blocks and standalone semicolons
+    $this->stmt('{', function($parse, $token) {
+      $statements= $this->statements($parse);
+      $parse->expecting('}', 'block');
+      return new Block($statements, $token->line);
+    });
     $this->stmt(';', function($parse, $token) { return null; });
 
     // Unexpected standalone symbols, warn but continue
@@ -886,14 +884,10 @@ class PHP extends Language {
 
       // Function expression used as statement (e.g. for pure side-effects!)
       if ('(' === $parse->token->value) {
-        $parse->queue= [$parse->token];
+        array_unshift($parse->queue, $parse->token);
         $parse->token= new Token($this->symbol('function'));
         $parse->token->line= $token->line;
-        $expr= $this->expression($parse, 0);
-
-        $parse->queue= [$parse->token];
-        $parse->token= new Token($this->symbol(';'));
-        return $expr;
+        return $this->expression($parse, 0);
       }
 
       if ('&' === $parse->token->value) {
@@ -907,9 +901,19 @@ class PHP extends Language {
       $parse->forward();
 
       $signature= $this->signature($parse, $byref);
-      $parse->expecting('{', 'function');
-      $statements= $this->statements($parse);
-      $parse->expecting('}', 'function');
+
+      if ('{' === $parse->token->value) {
+        $parse->forward();
+        $statements= $this->statements($parse);
+        $parse->expecting('}', 'function');
+      } else if ('=>' === $parse->token->value) {
+        $parse->forward();
+        $expr= $this->expression($parse, 0);
+        $statements= [new ReturnStatement($expr, $expr->line)];
+        $parse->expecting(';', 'function');
+      } else {
+        $parse->expecting('=> or { ... }', 'function');
+      }
 
       return new FunctionDeclaration($name, $signature, $statements, $token->line);
     });
@@ -1142,6 +1146,11 @@ class PHP extends Language {
         $parse->forward();
         $statements= $this->statements($parse);
         $parse->expecting('}', 'method declaration');
+      } else if ('=>' === $parse->token->value) {  // Single-expression method
+        $parse->forward();
+        $expr= $this->expression($parse, 0);
+        $statements= [new ReturnStatement($expr, $expr->line)];
+        $parse->expecting(';', 'method declaration');
       } else if (';' === $parse->token->value) {   // Abstract or interface method
         $statements= null;
         $parse->expecting(';', 'method declaration');
@@ -1591,6 +1600,29 @@ class PHP extends Language {
     return $parameters;
   }
 
+  public function scope($parse, $context) {
+    if ('=>' === $parse->token->value) {
+      $parse->forward();
+
+      // BC: Support deprecated arrow block syntax
+      if ('{' === $parse->token->value) {
+        trigger_error('Arrow block syntax `=> { ... }`', E_USER_DEPRECATED);
+        goto block;
+      }
+
+      return $this->expression($parse, 0);
+    } else if ('{' === $parse->token->value) {
+      block: $line= $parse->token->line;
+      $parse->forward();
+      $statements= $this->statements($parse);
+      $parse->expecting('}', $context);
+      return new Block($statements, $line);
+    } else {
+      $parse->expecting('=> or { ... }', $context);
+      return null;
+    }
+  }
+
   public function body($id, $func) {
     $this->body[$id]= $func->bindTo($this, static::class);
   }
@@ -1689,9 +1721,18 @@ class PHP extends Language {
       $return= null;
     }
 
-    $parse->expecting('{', 'function');
-    $statements= $this->statements($parse);
-    $parse->expecting('}', 'function');
+    if ('{' === $parse->token->value) {
+      $parse->forward();
+      $statements= $this->statements($parse);
+      $parse->expecting('}', 'function');
+    } else if ('=>' === $parse->token->value) {
+      $parse->forward();
+      $expr= $this->expression($parse, 0);
+      $statements= [new ReturnStatement($expr, $expr->line)];
+      $parse->expecting(';', 'function');
+    } else {
+      $parse->expecting('=> or { ... }', 'function');
+    }
 
     return new ClosureExpression(new Signature($parameters, $return, false, $line), $use, $statements, $static, $line);
   }

--- a/src/main/php/lang/ast/syntax/PHP.class.php
+++ b/src/main/php/lang/ast/syntax/PHP.class.php
@@ -901,21 +901,9 @@ class PHP extends Language {
       $parse->forward();
 
       $signature= $this->signature($parse, $byref);
+      $scope= $this->scope($parse, 'function');
 
-      if ('{' === $parse->token->value) {
-        $parse->forward();
-        $statements= $this->statements($parse);
-        $parse->expecting('}', 'function');
-      } else if ('=>' === $parse->token->value) {
-        $parse->forward();
-        $expr= $this->expression($parse, 0);
-        $statements= [new ReturnStatement($expr, $expr->line)];
-        $parse->expecting(';', 'function');
-      } else {
-        $parse->expecting('=> or { ... }', 'function');
-      }
-
-      return new FunctionDeclaration($name, $signature, $statements, $token->line);
+      return new FunctionDeclaration($name, $signature, $scope, $token->line);
     });
 
     $this->stmt('class', function($parse, $token) {
@@ -1142,20 +1130,20 @@ class PHP extends Language {
       $parse->forward();
       $signature= $this->signature($parse, $byref);
 
-      if ('{' === $parse->token->value) {          // Regular body
+      // Cannot use scope() here as we require a semicolon after single-expressions
+      if ('{' === $parse->token->value) {
         $parse->forward();
-        $statements= $this->statements($parse);
+        $scope= new Block($this->statements($parse), $parse->token->line);
         $parse->expecting('}', 'method declaration');
-      } else if ('=>' === $parse->token->value) {  // Single-expression method
+      } else if ('=>' === $parse->token->value) {
         $parse->forward();
-        $expr= $this->expression($parse, 0);
-        $statements= [new ReturnStatement($expr, $expr->line)];
+        $scope= $this->expression($parse, 0);
         $parse->expecting(';', 'method declaration');
-      } else if (';' === $parse->token->value) {   // Abstract or interface method
-        $statements= null;
+      } else if (';' === $parse->token->value) {
+        $scope= null;
         $parse->expecting(';', 'method declaration');
       } else {
-        $parse->expecting('{ or ;', 'method declaration');
+        $parse->expecting('{, => or ;', 'method declaration');
         return;
       }
 
@@ -1163,7 +1151,7 @@ class PHP extends Language {
         $modifiers,
         $name,
         $signature,
-        $statements,
+        $scope,
         $meta[DETAIL_ANNOTATIONS] ?? null,
         $comment,
         $line
@@ -1721,20 +1709,8 @@ class PHP extends Language {
       $return= null;
     }
 
-    if ('{' === $parse->token->value) {
-      $parse->forward();
-      $statements= $this->statements($parse);
-      $parse->expecting('}', 'function');
-    } else if ('=>' === $parse->token->value) {
-      $parse->forward();
-      $expr= $this->expression($parse, 0);
-      $statements= [new ReturnStatement($expr, $expr->line)];
-      $parse->expecting(';', 'function');
-    } else {
-      $parse->expecting('=> or { ... }', 'function');
-    }
-
-    return new ClosureExpression(new Signature($parameters, $return, false, $line), $use, $statements, $static, $line);
+    $scope= $this->scope($parse, 'function');
+    return new ClosureExpression(new Signature($parameters, $return, false, $line), $use, $scope, $static, $line);
   }
 
   public function block($parse) {

--- a/src/test/php/lang/ast/unittest/parse/BracedTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/BracedTest.class.php
@@ -1,6 +1,7 @@
 <?php namespace lang\ast\unittest\parse;
 
 use lang\ast\nodes\{
+  Block,
   Braced,
   ClosureExpression,
   InvokeExpression,
@@ -70,7 +71,7 @@ class BracedTest extends ParseTest {
       self::LINE
     );
     $this->assertParsed(
-      [new Braced(new ClosureExpression($signature, null, [], false, self::LINE), self::LINE)],
+      [new Braced(new ClosureExpression($signature, null, new Block([], self::LINE), false, self::LINE), self::LINE)],
       '(function(T &$arg) { });'
     );
   }

--- a/src/test/php/lang/ast/unittest/parse/ClosuresTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/ClosuresTest.class.php
@@ -2,6 +2,7 @@
 
 use lang\ast\nodes\{
   BinaryExpression,
+  Block,
   Braced,
   ClosureExpression,
   InvokeExpression,
@@ -19,22 +20,28 @@ class ClosuresTest extends ParseTest {
 
   #[Before]
   public function returns() {
-    $this->returns= new ReturnStatement(
-      new BinaryExpression(
-        new Variable('a', self::LINE),
-        '+',
-        new Literal('1', self::LINE),
+    $this->returns= new Block(
+      [new ReturnStatement(
+        new BinaryExpression(
+          new Variable('a', self::LINE),
+          '+',
+          new Literal('1', self::LINE),
+          self::LINE
+        ),
         self::LINE
-      ),
+      )],
       self::LINE
     );
   }
 
   #[Before]
   public function invoke() {
-    $this->invoke= new InvokeExpression(
-      new Literal('var_dump', self::LINE),
-      [new Literal('true', self::LINE)],
+    $this->invoke= new Block(
+      [new InvokeExpression(
+        new Literal('var_dump', self::LINE),
+        [new Literal('true', self::LINE)],
+        self::LINE
+      )],
       self::LINE
     );
   }
@@ -42,14 +49,14 @@ class ClosuresTest extends ParseTest {
   #[Test]
   public function with_body() {
     $this->assertParsed(
-      [new ClosureExpression(new Signature([], null, false, self::LINE), null, [$this->returns], false, self::LINE)],
+      [new ClosureExpression(new Signature([], null, false, self::LINE), null, $this->returns, false, self::LINE)],
       'function() { return $a + 1; };'
     );
   }
 
   #[Test]
   public function single_expression() {
-    $scope= [new ReturnStatement(new Literal('true', self::LINE), self::LINE)];
+    $scope= new Literal('true', self::LINE);
     $this->assertParsed(
       [new ClosureExpression(new Signature([], null, false, self::LINE), null, $scope, false, self::LINE)],
       'function() => true;'
@@ -60,7 +67,7 @@ class ClosuresTest extends ParseTest {
   public function with_param() {
     $params= [new Parameter('a', null, null, false, false, null, null, null, self::LINE)];
     $this->assertParsed(
-      [new ClosureExpression(new Signature($params, null, false, self::LINE), null, [$this->returns], false, self::LINE)],
+      [new ClosureExpression(new Signature($params, null, false, self::LINE), null, $this->returns, false, self::LINE)],
       'function($a) { return $a + 1; };'
     );
   }
@@ -68,7 +75,7 @@ class ClosuresTest extends ParseTest {
   #[Test]
   public function with_use_by_value() {
     $this->assertParsed(
-      [new ClosureExpression(new Signature([], null, false, self::LINE), ['$a', '$b'], [$this->returns], false, self::LINE)],
+      [new ClosureExpression(new Signature([], null, false, self::LINE), ['$a', '$b'], $this->returns, false, self::LINE)],
       'function() use($a, $b) { return $a + 1; };'
     );
   }
@@ -76,7 +83,7 @@ class ClosuresTest extends ParseTest {
   #[Test]
   public function with_use_and_return() {
     $this->assertParsed(
-      [new ClosureExpression(new Signature([], new Type('int'), false, self::LINE), ['$a'], [$this->returns], false, self::LINE)],
+      [new ClosureExpression(new Signature([], new Type('int'), false, self::LINE), ['$a'], $this->returns, false, self::LINE)],
       'function() use($a): int { return $a + 1; };'
     );
   }
@@ -84,7 +91,7 @@ class ClosuresTest extends ParseTest {
   #[Test]
   public function with_use_by_reference() {
     $this->assertParsed(
-      [new ClosureExpression(new Signature([], null, false, self::LINE), ['$a', '&$b'], [$this->returns], false, self::LINE)],
+      [new ClosureExpression(new Signature([], null, false, self::LINE), ['$a', '&$b'], $this->returns, false, self::LINE)],
       'function() use($a, &$b) { return $a + 1; };'
     );
   }
@@ -92,7 +99,7 @@ class ClosuresTest extends ParseTest {
   #[Test]
   public function with_return_type() {
     $this->assertParsed(
-      [new ClosureExpression(new Signature([], new Type('int'), false, self::LINE), null, [$this->invoke], false, self::LINE)],
+      [new ClosureExpression(new Signature([], new Type('int'), false, self::LINE), null, $this->invoke, false, self::LINE)],
       'function(): int { var_dump(true); };'
     );
   }
@@ -100,7 +107,7 @@ class ClosuresTest extends ParseTest {
   #[Test]
   public function with_nullable_return_type() {
     $this->assertParsed(
-      [new ClosureExpression(new Signature([], new Type('?int'), false, self::LINE), null, [$this->invoke], false, self::LINE)],
+      [new ClosureExpression(new Signature([], new Type('?int'), false, self::LINE), null, $this->invoke, false, self::LINE)],
       'function(): ?int { var_dump(true); };'
     );
   }
@@ -108,7 +115,7 @@ class ClosuresTest extends ParseTest {
   #[Test]
   public function static_function() {
     $this->assertParsed(
-      [new ClosureExpression(new Signature([], null, false, self::LINE), null, [$this->invoke], true, self::LINE)],
+      [new ClosureExpression(new Signature([], null, false, self::LINE), null, $this->invoke, true, self::LINE)],
       'static function() { var_dump(true); };'
     );
   }
@@ -119,7 +126,7 @@ class ClosuresTest extends ParseTest {
     $this->assertParsed(
       [new InvokeExpression(
         new Braced(
-          new ClosureExpression(new Signature([], null, false, self::LINE), null, [$this->invoke], false, self::LINE),
+          new ClosureExpression(new Signature([], null, false, self::LINE), null, $this->invoke, false, self::LINE),
           self::LINE
         ),
         [],

--- a/src/test/php/lang/ast/unittest/parse/ClosuresTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/ClosuresTest.class.php
@@ -48,6 +48,15 @@ class ClosuresTest extends ParseTest {
   }
 
   #[Test]
+  public function single_expression() {
+    $scope= [new ReturnStatement(new Literal('true', self::LINE), self::LINE)];
+    $this->assertParsed(
+      [new ClosureExpression(new Signature([], null, false, self::LINE), null, $scope, false, self::LINE)],
+      'function() => true;'
+    );
+  }
+
+  #[Test]
   public function with_param() {
     $params= [new Parameter('a', null, null, false, false, null, null, null, self::LINE)];
     $this->assertParsed(

--- a/src/test/php/lang/ast/unittest/parse/CommentTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/CommentTest.class.php
@@ -1,6 +1,6 @@
 <?php namespace lang\ast\unittest\parse;
 
-use lang\ast\nodes\{Annotations, ClassDeclaration, Comment, Constant, Literal, Method, Property, Signature};
+use lang\ast\nodes\{Annotations, Block, ClassDeclaration, Comment, Constant, Literal, Method, Property, Signature};
 use lang\ast\types\IsValue;
 use test\{Assert, Test};
 
@@ -146,7 +146,14 @@ class CommentTest extends ParseTest {
   #[Test]
   public function apidoc_comment_attached_to_next_method() {
     $class= new ClassDeclaration([], new IsValue('\\T'), null, [], [], null, null, 2);
-    $class->declare(new Method(['public'], '__construct', new Signature([], null, false, 4), [], null, new Comment('/** @api */', 3), 4));
+    $class->declare(new Method(
+      ['public'],
+      '__construct',
+      new Signature([], null, false, 4),
+      new Block([], 4),
+      null,
+      new Comment('/** @api */', 3), 4)
+    );
 
     $this->assertParsed([$class], '
       class T {

--- a/src/test/php/lang/ast/unittest/parse/FunctionsTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/FunctionsTest.class.php
@@ -4,6 +4,7 @@ use lang\ast\nodes\{
   ArrayLiteral,
   Assignment,
   BinaryExpression,
+  Block,
   Braced,
   FunctionDeclaration,
   Literal,
@@ -15,9 +16,10 @@ use lang\ast\nodes\{
   YieldFromExpression
 };
 use lang\ast\types\{IsFunction, IsLiteral, IsNullable, IsUnion, IsValue};
-use test\{Assert, Test, Values};
+use test\{Assert, Before, Test, Values};
 
 class FunctionsTest extends ParseTest {
+  private $empty;
 
   /** @return iterable */
   private function types() {
@@ -33,17 +35,22 @@ class FunctionsTest extends ParseTest {
     yield ['(function(): string)', new IsFunction([], new IsLiteral('string'))];
   }
 
+  #[Before]
+  public function empty() {
+    $this->empty= new Block([], self::LINE);
+  }
+
   #[Test]
   public function empty_function_without_parameters() {
     $this->assertParsed(
-      [new FunctionDeclaration('a', new Signature([], null, false, self::LINE), [], self::LINE)],
+      [new FunctionDeclaration('a', new Signature([], null, false, self::LINE), $this->empty, self::LINE)],
       'function a() { }'
     );
   }
 
   #[Test]
   public function single_expression_function() {
-    $scope= [new ReturnStatement(new Literal('"A"', self::LINE), self::LINE)];
+    $scope= new Literal('"A"', self::LINE);
     $this->assertParsed(
       [new FunctionDeclaration('a', new Signature([], null, false, self::LINE), $scope, self::LINE)],
       'function a() => "A";'
@@ -53,7 +60,7 @@ class FunctionsTest extends ParseTest {
   #[Test]
   public function returning_by_reference() {
     $this->assertParsed(
-      [new FunctionDeclaration('a', new Signature([], null, true, self::LINE), [], self::LINE)],
+      [new FunctionDeclaration('a', new Signature([], null, true, self::LINE), $this->empty, self::LINE)],
       'function &a() { }'
     );
   }
@@ -62,8 +69,8 @@ class FunctionsTest extends ParseTest {
   public function two_functions() {
     $this->assertParsed(
       [
-        new FunctionDeclaration('a', new Signature([], null, false, self::LINE), [], self::LINE),
-        new FunctionDeclaration('b', new Signature([], null, false, self::LINE), [], self::LINE)
+        new FunctionDeclaration('a', new Signature([], null, false, self::LINE), $this->empty, self::LINE),
+        new FunctionDeclaration('b', new Signature([], null, false, self::LINE), $this->empty, self::LINE)
       ],
       'function a() { } function b() { }'
     );
@@ -73,7 +80,7 @@ class FunctionsTest extends ParseTest {
   public function with_parameter($name) {
     $params= [new Parameter($name, null, null, false, false, null, null, null, self::LINE)];
     $this->assertParsed(
-      [new FunctionDeclaration('a', new Signature($params, null, false, self::LINE), [], self::LINE)],
+      [new FunctionDeclaration('a', new Signature($params, null, false, self::LINE), $this->empty, self::LINE)],
       'function a($'.$name.') { }'
     );
   }
@@ -82,7 +89,7 @@ class FunctionsTest extends ParseTest {
   public function with_reference_parameter() {
     $params= [new Parameter('param', null, null, true, false, null, null, null, self::LINE)];
     $this->assertParsed(
-      [new FunctionDeclaration('a', new Signature($params, null, false, self::LINE), [], self::LINE)],
+      [new FunctionDeclaration('a', new Signature($params, null, false, self::LINE), $this->empty, self::LINE)],
       'function a(&$param) { }'
     );
   }
@@ -91,7 +98,7 @@ class FunctionsTest extends ParseTest {
   public function dangling_comma_in_parameter_lists() {
     $params= [new Parameter('param', null, null, false, false, null, null, null, self::LINE)];
     $this->assertParsed(
-      [new FunctionDeclaration('a', new Signature($params, null, false, self::LINE), [], self::LINE)],
+      [new FunctionDeclaration('a', new Signature($params, null, false, self::LINE), $this->empty, self::LINE)],
       'function a($param, ) { }'
     );
   }
@@ -100,7 +107,7 @@ class FunctionsTest extends ParseTest {
   public function with_typed_parameter($declaration, $expected) {
     $params= [new Parameter('param', $expected, null, false, false, null, null, null, self::LINE)];
     $this->assertParsed(
-      [new FunctionDeclaration('a', new Signature($params, null, false, self::LINE), [], self::LINE)],
+      [new FunctionDeclaration('a', new Signature($params, null, false, self::LINE), $this->empty, self::LINE)],
       'function a('.$declaration.' $param) { }'
     );
   }
@@ -109,7 +116,7 @@ class FunctionsTest extends ParseTest {
   public function with_nullable_typed_parameter() {
     $params= [new Parameter('param', new IsNullable(new IsLiteral('string')), null, false, false, null, null, null, self::LINE)];
     $this->assertParsed(
-      [new FunctionDeclaration('a', new Signature($params, null, false, self::LINE), [], self::LINE)],
+      [new FunctionDeclaration('a', new Signature($params, null, false, self::LINE), $this->empty, self::LINE)],
       'function a(?string $param) { }'
     );
   }
@@ -118,7 +125,7 @@ class FunctionsTest extends ParseTest {
   public function with_variadic_parameter() {
     $params= [new Parameter('param', null, null, false, true, null, null, null, self::LINE)];
     $this->assertParsed(
-      [new FunctionDeclaration('a', new Signature($params, null, false, self::LINE), [], self::LINE)],
+      [new FunctionDeclaration('a', new Signature($params, null, false, self::LINE), $this->empty, self::LINE)],
       'function a(... $param) { }'
     );
   }
@@ -127,7 +134,7 @@ class FunctionsTest extends ParseTest {
   public function with_optional_parameter() {
     $params= [new Parameter('param', null, new Literal('null', self::LINE), false, false, null, null, null, self::LINE)];
     $this->assertParsed(
-      [new FunctionDeclaration('a', new Signature($params, null, false, self::LINE), [], self::LINE)],
+      [new FunctionDeclaration('a', new Signature($params, null, false, self::LINE), $this->empty, self::LINE)],
       'function a($param= null) { }'
     );
   }
@@ -136,7 +143,7 @@ class FunctionsTest extends ParseTest {
   public function with_parameter_named_function() {
     $params= [new Parameter('function', null, null, false, false, null, null, null, self::LINE)];
     $this->assertParsed(
-      [new FunctionDeclaration('a', new Signature($params, null, false, self::LINE), [], self::LINE)],
+      [new FunctionDeclaration('a', new Signature($params, null, false, self::LINE), $this->empty, self::LINE)],
       'function a($function, ) { }'
     );
   }
@@ -145,7 +152,7 @@ class FunctionsTest extends ParseTest {
   public function with_typed_parameter_named_function() {
     $params= [new Parameter('function', new IsFunction([], new IsLiteral('void')), null, false, false, null, null, null, self::LINE)];
     $this->assertParsed(
-      [new FunctionDeclaration('a', new Signature($params, null, false, self::LINE), [], self::LINE)],
+      [new FunctionDeclaration('a', new Signature($params, null, false, self::LINE), $this->empty, self::LINE)],
       'function a((function(): void) $function) { }'
     );
   }
@@ -153,7 +160,7 @@ class FunctionsTest extends ParseTest {
   #[Test, Values(from: 'types')]
   public function with_return_type($declaration, $expected) {
     $this->assertParsed(
-      [new FunctionDeclaration('a', new Signature([], $expected, false, self::LINE), [], self::LINE)],
+      [new FunctionDeclaration('a', new Signature([], $expected, false, self::LINE), $this->empty, self::LINE)],
       'function a(): '.$declaration.' { }'
     );
   }
@@ -162,7 +169,7 @@ class FunctionsTest extends ParseTest {
   public function generator() {
     $yield= new YieldExpression(null, null, self::LINE);
     $this->assertParsed(
-      [new FunctionDeclaration('a', new Signature([], null, false, self::LINE), [$yield], self::LINE)],
+      [new FunctionDeclaration('a', new Signature([], null, false, self::LINE), new Block([$yield], self::LINE), self::LINE)],
       'function a() { yield; }'
     );
   }
@@ -171,7 +178,7 @@ class FunctionsTest extends ParseTest {
   public function generator_with_value() {
     $yield= new YieldExpression(null, new Literal('1', self::LINE), self::LINE);
     $this->assertParsed(
-      [new FunctionDeclaration('a', new Signature([], null, false, self::LINE), [$yield], self::LINE)],
+      [new FunctionDeclaration('a', new Signature([], null, false, self::LINE), new Block([$yield], self::LINE), self::LINE)],
       'function a() { yield 1; }'
     );
   }
@@ -180,7 +187,7 @@ class FunctionsTest extends ParseTest {
   public function generator_with_key_and_value() {
     $yield= new YieldExpression(new Literal('"number"', self::LINE), new Literal('1', self::LINE), self::LINE);
     $this->assertParsed(
-      [new FunctionDeclaration('a', new Signature([], null, false, self::LINE), [$yield], self::LINE)],
+      [new FunctionDeclaration('a', new Signature([], null, false, self::LINE), new Block([$yield], self::LINE), self::LINE)],
       'function a() { yield "number" => 1; }'
     );
   }
@@ -189,7 +196,7 @@ class FunctionsTest extends ParseTest {
   public function generator_delegation() {
     $yield= new YieldFromExpression(new ArrayLiteral([], self::LINE), self::LINE);
     $this->assertParsed(
-      [new FunctionDeclaration('a', new Signature([], null, false, self::LINE), [$yield], self::LINE)],
+      [new FunctionDeclaration('a', new Signature([], null, false, self::LINE), new Block([$yield], self::LINE), self::LINE)],
       'function a() { yield from []; }'
     );
   }
@@ -203,7 +210,7 @@ class FunctionsTest extends ParseTest {
       self::LINE
     );
     $this->assertParsed(
-      [new FunctionDeclaration('a', new Signature([], null, false, self::LINE), [$yield], self::LINE)],
+      [new FunctionDeclaration('a', new Signature([], null, false, self::LINE), new Block([$yield], self::LINE), self::LINE)],
       'function a() { $value= yield; }'
     );
   }
@@ -217,7 +224,7 @@ class FunctionsTest extends ParseTest {
       self::LINE
     );
     $this->assertParsed(
-      [new FunctionDeclaration('a', new Signature([], null, false, self::LINE), [$yield], self::LINE)],
+      [new FunctionDeclaration('a', new Signature([], null, false, self::LINE), new Block([$yield], self::LINE), self::LINE)],
       'function a() { $value= yield (1); }'
     );
   }
@@ -232,7 +239,7 @@ class FunctionsTest extends ParseTest {
       self::LINE
     );
     $this->assertParsed(
-      [new FunctionDeclaration('a', new Signature([], null, false, self::LINE), [$yield], self::LINE)],
+      [new FunctionDeclaration('a', new Signature([], null, false, self::LINE), new Block([$yield], self::LINE), self::LINE)],
       'function a() { $value= (yield); }'
     );
   }
@@ -246,7 +253,7 @@ class FunctionsTest extends ParseTest {
       self::LINE
     );
     $this->assertParsed(
-      [new FunctionDeclaration('a', new Signature([], null, false, self::LINE), [$yield], self::LINE)],
+      [new FunctionDeclaration('a', new Signature([], null, false, self::LINE), new Block([$yield], self::LINE), self::LINE)],
       $declaration
     );
   }
@@ -260,7 +267,7 @@ class FunctionsTest extends ParseTest {
       self::LINE
     );
     $this->assertParsed(
-      [new FunctionDeclaration('a', new Signature([], null, false, self::LINE), [$yield], self::LINE)],
+      [new FunctionDeclaration('a', new Signature([], null, false, self::LINE), new Block([$yield], self::LINE), self::LINE)],
       $declaration
     );
   }

--- a/src/test/php/lang/ast/unittest/parse/FunctionsTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/FunctionsTest.class.php
@@ -42,6 +42,15 @@ class FunctionsTest extends ParseTest {
   }
 
   #[Test]
+  public function single_expression_function() {
+    $scope= [new ReturnStatement(new Literal('"A"', self::LINE), self::LINE)];
+    $this->assertParsed(
+      [new FunctionDeclaration('a', new Signature([], null, false, self::LINE), $scope, self::LINE)],
+      'function a() => "A";'
+    );
+  }
+
+  #[Test]
   public function returning_by_reference() {
     $this->assertParsed(
       [new FunctionDeclaration('a', new Signature([], null, true, self::LINE), [], self::LINE)],

--- a/src/test/php/lang/ast/unittest/parse/LambdasTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/LambdasTest.class.php
@@ -49,7 +49,35 @@ class LambdasTest extends ParseTest {
         false,
         self::LINE
       )],
+      'fn($a) { return $a + 1; };'
+    );
+  }
+
+  #[Test]
+  public function static_short_closure_with_block() {
+    $this->assertParsed(
+      [new LambdaExpression(
+        new Signature([$this->parameter], null, false, self::LINE),
+        new Block([new ReturnStatement($this->expression, self::LINE)], self::LINE),
+        true,
+        self::LINE
+      )],
+      'static fn($a) { return $a + 1; };'
+    );
+  }
+
+  /** @deprecated */
+  #[Test]
+  public function short_closure_with_arrow_and_block() {
+    $this->assertParsed(
+      [new LambdaExpression(
+        new Signature([$this->parameter], null, false, self::LINE),
+        new Block([new ReturnStatement($this->expression, self::LINE)], self::LINE),
+        false,
+        self::LINE
+      )],
       'fn($a) => { return $a + 1; };'
     );
+    \xp::gc(); // Swallow deprecation warning
   }
 }

--- a/src/test/php/lang/ast/unittest/parse/MatchExpressionTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/MatchExpressionTest.class.php
@@ -36,11 +36,24 @@ class MatchExpressionTest extends ParseTest {
   }
 
   #[Test]
-  public function match_with_block() {
+  public function match_with_default_block() {
     $default= new Block([new ReturnStatement(new Literal('false', self::LINE), self::LINE)], self::LINE);
     $this->assertParsed(
       [new MatchExpression(new Variable('arg', self::LINE), [], $default, self::LINE)],
-      'match ($arg) { default => { return false; } };'
+      'match ($arg) { default { return false; } };'
+    );
+  }
+
+  #[Test]
+  public function match_with_case_block() {
+    $cases= [new MatchCondition(
+      [new Literal('0', self::LINE)],
+      new Block([new ReturnStatement(new Literal('false', self::LINE), self::LINE)], self::LINE),
+      self::LINE
+    )];
+    $this->assertParsed(
+      [new MatchExpression(new Variable('arg', self::LINE), $cases, null, self::LINE)],
+      'match ($arg) { 0 { return false; } };'
     );
   }
 

--- a/src/test/php/lang/ast/unittest/parse/MembersTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/MembersTest.class.php
@@ -20,9 +20,10 @@ use lang\ast\nodes\{
   Parameter
 };
 use lang\ast\types\{IsFunction, IsLiteral, IsNullable, IsUnion, IsValue, IsGeneric};
-use test\{Assert, Test, Values};
+use test\{Assert, Before, Test, Values};
 
 class MembersTest extends ParseTest {
+  private $empty;
 
   /** @return iterable */
   private function types() {
@@ -36,6 +37,11 @@ class MembersTest extends ParseTest {
     yield ['string|(function(): void)', new IsUnion([new IsLiteral('string'), new IsFunction([], new IsLiteral('void'))])];
     yield ['function(): string', new IsFunction([], new IsLiteral('string'))];
     yield ['(function(): string)', new IsFunction([], new IsLiteral('string'))];
+  }
+
+  #[Before]
+  public function empty() {
+    $this->empty= new Block([], self::LINE);
   }
 
   #[Test]
@@ -66,7 +72,7 @@ class MembersTest extends ParseTest {
   #[Test]
   public function private_instance_method() {
     $class= new ClassDeclaration([], new IsValue('\\A'), null, [], [], null, null, self::LINE);
-    $class->declare(new Method(['private'], 'a', new Signature([], null, false, self::LINE), [], null, null, self::LINE));
+    $class->declare(new Method(['private'], 'a', new Signature([], null, false, self::LINE), $this->empty, null, null, self::LINE));
 
     $this->assertParsed([$class], 'class A { private function a() { } }');
   }
@@ -74,7 +80,7 @@ class MembersTest extends ParseTest {
   #[Test]
   public function private_static_method() {
     $class= new ClassDeclaration([], new IsValue('\\A'), null, [], [], null, null, self::LINE);
-    $class->declare(new Method(['private', 'static'], 'a', new Signature([], null, false, self::LINE), [], null, null, self::LINE));
+    $class->declare(new Method(['private', 'static'], 'a', new Signature([], null, false, self::LINE), $this->empty, null, null, self::LINE));
 
     $this->assertParsed([$class], 'class A { private static function a() { } }');
   }
@@ -82,14 +88,14 @@ class MembersTest extends ParseTest {
   #[Test]
   public function method_returning_reference() {
     $class= new ClassDeclaration([], new IsValue('\\A'), null, [], [], null, null, self::LINE);
-    $class->declare(new Method(['private', 'static'], 'a', new Signature([], null, true, self::LINE), [], null, null, self::LINE));
+    $class->declare(new Method(['private', 'static'], 'a', new Signature([], null, true, self::LINE), $this->empty, null, null, self::LINE));
 
     $this->assertParsed([$class], 'class A { private static function &a() { } }');
   }
 
   #[Test]
   public function single_expression_method() {
-    $scope= [new ReturnStatement(new Literal('"A"', self::LINE), self::LINE)];
+    $scope= new Literal('"A"', self::LINE);
     $class= new ClassDeclaration([], new IsValue('\\A'), null, [], [], null, null, self::LINE);
     $class->declare(new Method(['private'], 'a', new Signature([], null, false, self::LINE), $scope, null, null, self::LINE));
 
@@ -125,7 +131,7 @@ class MembersTest extends ParseTest {
   public function method_with_typed_parameter($declaration, $expected) {
     $class= new ClassDeclaration([], new IsValue('\\A'), null, [], [], null, null, self::LINE);
     $params= [new Parameter('param', $expected, null, false, false, null, null, null, self::LINE)];
-    $class->declare(new Method(['public'], 'a', new Signature($params, null, false, self::LINE), [], null, null, self::LINE));
+    $class->declare(new Method(['public'], 'a', new Signature($params, null, false, self::LINE), $this->empty, null, null, self::LINE));
 
     $this->assertParsed([$class], 'class A { public function a('.$declaration.' $param) { } }');
   }
@@ -133,7 +139,7 @@ class MembersTest extends ParseTest {
   #[Test, Values(from: 'types')]
   public function method_with_return_type($declaration, $expected) {
     $class= new ClassDeclaration([], new IsValue('\\A'), null, [], [], null, null, self::LINE);
-    $class->declare(new Method(['public'], 'a', new Signature([], $expected, false, self::LINE), [], null, null, self::LINE));
+    $class->declare(new Method(['public'], 'a', new Signature([], $expected, false, self::LINE), $this->empty, null, null, self::LINE));
 
     $this->assertParsed([$class], 'class A { public function a(): '.$declaration.' { } }');
   }
@@ -142,7 +148,7 @@ class MembersTest extends ParseTest {
   public function method_with_annotation() {
     $annotations= new Annotations(['Test' => []], self::LINE);
     $class= new ClassDeclaration([], new IsValue('\\A'), null, [], [], null, null, self::LINE);
-    $class->declare(new Method(['public'], 'a', new Signature([], null, false, self::LINE), [], $annotations, null, self::LINE));
+    $class->declare(new Method(['public'], 'a', new Signature([], null, false, self::LINE), $this->empty, $annotations, null, self::LINE));
 
     $this->assertParsed([$class], 'class A { #[Test] public function a() { } }');
   }
@@ -151,7 +157,7 @@ class MembersTest extends ParseTest {
   public function method_with_annotations() {
     $annotations= new Annotations(['Test' => [], 'Ignore' => [new Literal('"Not implemented"', self::LINE)]], self::LINE);
     $class= new ClassDeclaration([], new IsValue('\\A'), null, [], [], null, null, self::LINE);
-    $class->declare(new Method(['public'], 'a', new Signature([], null, false, self::LINE), [], $annotations, null, self::LINE));
+    $class->declare(new Method(['public'], 'a', new Signature([], null, false, self::LINE), $this->empty, $annotations, null, self::LINE));
 
     $this->assertParsed([$class], 'class A { #[Test, Ignore("Not implemented")] public function a() { } }');
   }
@@ -410,7 +416,7 @@ class MembersTest extends ParseTest {
   public function asymmetric_property_as_constructor_argument() {
     $params= [new Parameter('a', new IsLiteral('int'), null, false, false, ['private(set)'], null, null, self::LINE)];
     $class= new ClassDeclaration([], new IsValue('\\A'), null, [], [], null, null, self::LINE);
-    $class->declare(new Method(['public'], '__construct', new Signature($params, null, false, self::LINE), [], null, null, self::LINE));
+    $class->declare(new Method(['public'], '__construct', new Signature($params, null, false, self::LINE), $this->empty, null, null, self::LINE));
 
     $this->assertParsed([$class], 'class A { public function __construct(private(set) int $a) { } }');
   }

--- a/src/test/php/lang/ast/unittest/parse/MembersTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/MembersTest.class.php
@@ -88,6 +88,15 @@ class MembersTest extends ParseTest {
   }
 
   #[Test]
+  public function single_expression_method() {
+    $scope= [new ReturnStatement(new Literal('"A"', self::LINE), self::LINE)];
+    $class= new ClassDeclaration([], new IsValue('\\A'), null, [], [], null, null, self::LINE);
+    $class->declare(new Method(['private'], 'a', new Signature([], null, false, self::LINE), $scope, null, null, self::LINE));
+
+    $this->assertParsed([$class], 'class A { private function a() => "A"; }');
+  }
+
+  #[Test]
   public function class_constant() {
     $class= new ClassDeclaration([], new IsValue('\\A'), null, [], [], null, null, self::LINE);
     $class->declare(new Constant([], 'T', null, new Literal('1', self::LINE), null, null, self::LINE));


### PR DESCRIPTION
## Idea

* `fn` captures variables from the surrounding scope, see https://wiki.php.net/rfc/scope-functions
* `function` does not
* `=> ...` is short for `{ return ... }`

## What this applies to

Methods:

```php
class T {
  public function name() => $this->name; // 🆕

  // Equivalent of
  // public function name() { return $this->name; }
}
```

Capturing closures:

```php
fn($a, $b) => $a + $b;

// Equivalent of
// fn($a, $b) { return $a + $b; } // 🆕
```

Closures:

```php
function($a, $b) => $a + $b; // 🆕

// Equivalent of
// function($a, $b) { return $a + $b; }
```

Functions:

```php
function add($a, $b) => $a + $b; // 🆕

// Equivalent of
// function add($a, $b) { return $a + $b; }
```