### PR TITLE
Emit strings and numbers as `lang.ast.nodes.Scalar`

### DIFF
--- a/src/main/php/lang/ast/Visitor.class.php
+++ b/src/main/php/lang/ast/Visitor.class.php
@@ -1,5 +1,7 @@
 <?php namespace lang\ast;
 
+use lang\ast\nodes\Literal;
+
 /**
  * Abstract base class for all visitors. Handles all node types without
  * doing anything.
@@ -237,6 +239,46 @@ abstract class Visitor {
    * @return var
    */
   public function literal($self) { }
+
+  /**
+   * Visits strings
+   *
+   * @param  lang.ast.Node $self
+   * @return var
+   */
+  public function string($self) {
+    return $this->literal(new Literal($self->literal, $self->line));
+  }
+
+  /**
+   * Visits heredoc
+   *
+   * @param  lang.ast.Node $self
+   * @return var
+   */
+  public function heredoc($self) {
+    return $this->literal(new Literal($self->literal, $self->line));
+  }
+
+  /**
+   * Visits integers
+   *
+   * @param  lang.ast.Node $self
+   * @return var
+   */
+  public function integer($self) {
+    return $this->literal(new Literal($self->literal, $self->line));
+  }
+
+  /**
+   * Visits decimals
+   *
+   * @param  lang.ast.Node $self
+   * @return var
+   */
+  public function decimal($self) {
+    return $this->literal(new Literal($self->literal, $self->line));
+  }
 
   /**
    * Visits methods

--- a/src/main/php/lang/ast/nodes/Scalar.class.php
+++ b/src/main/php/lang/ast/nodes/Scalar.class.php
@@ -1,0 +1,16 @@
+<?php namespace lang\ast\nodes;
+
+use lang\ast\Node;
+
+class Scalar extends Node {
+  public $literal;
+
+  public function __construct($literal, $kind, $line= -1) {
+    $this->literal= $literal;
+    $this->kind= $kind;
+    $this->line= $line;
+  }
+
+  /** @return string */
+  public function __toString() { return $this->literal; }
+}

--- a/src/main/php/lang/ast/syntax/PHP.class.php
+++ b/src/main/php/lang/ast/syntax/PHP.class.php
@@ -49,6 +49,7 @@ use lang\ast\nodes\{
   Placeholder,
   Property,
   ReturnStatement,
+  Scalar,
   ScopeExpression,
   Signature,
   StaticLocals,
@@ -484,7 +485,7 @@ class PHP extends Language {
     });
 
     $this->prefix('(literal)', 0, function($parse, $token) {
-      return new Literal($token->value, $token->line);
+      return new Scalar($token->value, $token->kind, $token->line);
     });
 
     $this->prefix('(name)', 0, function($parse, $token) {

--- a/src/test/php/lang/ast/unittest/parse/AttributesTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/AttributesTest.class.php
@@ -1,6 +1,6 @@
 <?php namespace lang\ast\unittest\parse;
 
-use lang\ast\nodes\{Annotated, ArrayLiteral, Literal};
+use lang\ast\nodes\{Annotated, ArrayLiteral, Literal, Scalar};
 use test\{Assert, Test, Values};
 
 /** @see https://wiki.php.net/rfc/shorter_attribute_syntax_change */
@@ -23,8 +23,8 @@ class AttributesTest extends ParseTest {
    */
   private function attributes() {
     yield ['#[Service]', ['Service' => []]];
-    yield ['#[Test(version: 1)]', ['Test' => ['version' => new Literal('1', self::LINE)]]];
-    yield ['#[Service, Version(1)]', ['Service' => [], 'Version' => [new Literal('1', self::LINE)]]];
+    yield ['#[Test(version: 1)]', ['Test' => ['version' => new Scalar('1', 'integer', self::LINE)]]];
+    yield ['#[Service, Version(1)]', ['Service' => [], 'Version' => [new Scalar('1', 'integer', self::LINE)]]];
   }
 
   /**
@@ -55,7 +55,15 @@ class AttributesTest extends ParseTest {
     );
   }
 
-  #[Test, Values(['"test"', '1', '1.5', 'true', 'false', 'null'])]
+  #[Test, Values([['"test"', 'string'], ['1', 'integer'], ['1.5', 'decimal']])]
+  public function with_scalar_argument($value, $kind) {
+    $this->assertAnnotated(
+      ['Service' => [new Scalar($value, $kind, self::LINE)]],
+      $this->type('#[Service('.$value.')] class T { }')
+    );
+  }
+
+  #[Test, Values(['true', 'false', 'null'])]
   public function with_literal_argument($value) {
     $this->assertAnnotated(
       ['Service' => [new Literal($value, self::LINE)]],
@@ -66,8 +74,8 @@ class AttributesTest extends ParseTest {
   #[Test]
   public function with_array_argument() {
     $elements= [
-      [null, new Literal('1', self::LINE)],
-      [null, new Literal('2', self::LINE)],
+      [null, new Scalar('1', 'integer', self::LINE)],
+      [null, new Scalar('2', 'integer', self::LINE)],
     ];
     $this->assertAnnotated(
       ['Service' => [new ArrayLiteral($elements, self::LINE)]],
@@ -78,8 +86,8 @@ class AttributesTest extends ParseTest {
   #[Test]
   public function with_map_argument() {
     $elements= [
-      [new Literal('"one"', self::LINE), new Literal('1', self::LINE)],
-      [new Literal('"two"', self::LINE), new Literal('2', self::LINE)],
+      [new Scalar('"one"', 'string', self::LINE), new Scalar('1', 'integer', self::LINE)],
+      [new Scalar('"two"', 'string', self::LINE), new Scalar('2', 'integer', self::LINE)],
     ];
     $this->assertAnnotated(
       ['Service' => [new ArrayLiteral($elements, self::LINE)]],
@@ -90,7 +98,7 @@ class AttributesTest extends ParseTest {
   #[Test]
   public function with_named_arguments() {
     $this->assertAnnotated(
-      ['Impl' => ['class' => new Literal('"T"', self::LINE), 'version' => new Literal('1', self::LINE)]],
+      ['Impl' => ['class' => new Scalar('"T"', 'string', self::LINE), 'version' => new Scalar('1', 'integer', self::LINE)]],
       $this->type('#[Impl(class: "T", version: 1)] class T { }')
     );
   }
@@ -98,8 +106,8 @@ class AttributesTest extends ParseTest {
   #[Test]
   public function multiline() {
     $elements= [
-      [new Literal('"one"', self::LINE + 2), new Literal('1', self::LINE + 2)],
-      [new Literal('"two"', self::LINE + 3), new Literal('2', self::LINE + 3)],
+      [new Scalar('"one"', 'string', self::LINE + 2), new Scalar('1', 'integer', self::LINE + 2)],
+      [new Scalar('"two"', 'string', self::LINE + 3), new Scalar('2', 'integer', self::LINE + 3)],
     ];
     $this->assertAnnotated(['Values' => [new ArrayLiteral($elements, self::LINE + 1)]], $this->type('
       #[Values([
@@ -127,7 +135,7 @@ class AttributesTest extends ParseTest {
   #[Test]
   public function with_two_arguments() {
     $this->assertAnnotated(
-      ['Service' => [new Literal('1', self::LINE), new Literal('2', self::LINE)]],
+      ['Service' => [new Scalar('1', 'integer', self::LINE), new Scalar('2', 'integer', self::LINE)]],
       $this->type('#[Service(1, 2)] class T { }')
     );
   }
@@ -135,7 +143,7 @@ class AttributesTest extends ParseTest {
   #[Test]
   public function two_annotations() {
     $this->assertAnnotated(
-      ['Author' => [new Literal('"Test"', self::LINE)], 'Version' => [new Literal('2', self::LINE)]],
+      ['Author' => [new Scalar('"Test"', 'string', self::LINE)], 'Version' => [new Scalar('2', 'integer', self::LINE)]],
       $this->type('#[Author("Test"), Version(2)] class T { }')
     );
   }
@@ -143,7 +151,7 @@ class AttributesTest extends ParseTest {
   #[Test]
   public function trailing_comma() {
     $this->assertAnnotated(
-      ['Author' => [new Literal('"Test"', self::LINE)]],
+      ['Author' => [new Scalar('"Test"', 'string', self::LINE)]],
       $this->type('#[Author("Test"), ] class T { }')
     );
   }

--- a/src/test/php/lang/ast/unittest/parse/ClosuresTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/ClosuresTest.class.php
@@ -9,6 +9,7 @@ use lang\ast\nodes\{
   Literal,
   Parameter,
   ReturnStatement,
+  Scalar,
   Signature,
   Variable
 };
@@ -25,7 +26,7 @@ class ClosuresTest extends ParseTest {
         new BinaryExpression(
           new Variable('a', self::LINE),
           '+',
-          new Literal('1', self::LINE),
+          new Scalar('1', 'integer', self::LINE),
           self::LINE
         ),
         self::LINE

--- a/src/test/php/lang/ast/unittest/parse/CommentTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/CommentTest.class.php
@@ -1,6 +1,6 @@
 <?php namespace lang\ast\unittest\parse;
 
-use lang\ast\nodes\{Annotations, Block, ClassDeclaration, Comment, Constant, Literal, Method, Property, Signature};
+use lang\ast\nodes\{Annotations, Block, ClassDeclaration, Comment, Constant, Literal, Method, Property, Scalar, Signature};
 use lang\ast\types\IsValue;
 use test\{Assert, Test};
 
@@ -8,7 +8,7 @@ class CommentTest extends ParseTest {
 
   #[Test]
   public function oneline_double_slash() {
-    $this->assertParsed([new Literal('"test"', 3)], '
+    $this->assertParsed([new Scalar('"test"', 'string', 3)], '
       // This is a comment
       "test";
     ');
@@ -16,14 +16,14 @@ class CommentTest extends ParseTest {
 
   #[Test]
   public function oneline_double_slash_at_end() {
-    $this->assertParsed([new Literal('"test"', 2)], '
+    $this->assertParsed([new Scalar('"test"', 'string', 2)], '
       "test";  // This is a comment
     ');
   }
 
   #[Test]
   public function two_oneline_double_slash() {
-    $this->assertParsed([new Literal('"test"', 4)], '
+    $this->assertParsed([new Scalar('"test"', 'string', 4)], '
       // This is a comment
       // This is another
       "test";
@@ -32,7 +32,7 @@ class CommentTest extends ParseTest {
 
   #[Test]
   public function oneline_hashtag() {
-    $this->assertParsed([new Literal('"test"', 3)], '
+    $this->assertParsed([new Scalar('"test"', 'string', 3)], '
       # This is a comment
       "test";
     ');
@@ -40,14 +40,14 @@ class CommentTest extends ParseTest {
 
   #[Test]
   public function oneline_hashtag_at_end() {
-    $this->assertParsed([new Literal('"test"', 2)], '
+    $this->assertParsed([new Scalar('"test"', 'string', 2)], '
       "test";  # This is a comment
     ');
   }
 
   #[Test]
   public function two_oneline_hashtags() {
-    $this->assertParsed([new Literal('"test"', 4)], '
+    $this->assertParsed([new Scalar('"test"', 'string', 4)], '
       # This is a comment
       # This is another
       "test";
@@ -56,7 +56,7 @@ class CommentTest extends ParseTest {
 
   #[Test]
   public function oneline_slash_asterisk() {
-    $this->assertParsed([new Literal('"test"', 3)], '
+    $this->assertParsed([new Scalar('"test"', 'string', 3)], '
       /* This is a comment */
       "test";
     ');
@@ -64,21 +64,21 @@ class CommentTest extends ParseTest {
 
   #[Test]
   public function oneline_slash_asterisk_at_end() {
-    $this->assertParsed([new Literal('"test"', 2)], '
+    $this->assertParsed([new Scalar('"test"', 'string', 2)], '
       "test";  /* This is a comment */
     ');
   }
 
   #[Test]
   public function oneline_slash_asterisk_inbetween() {
-    $this->assertParsed([new Literal('"before"', 2), new Literal('"after"', 2)], '
+    $this->assertParsed([new Scalar('"before"', 'string', 2), new Scalar('"after"', 'string', 2)], '
       "before"; /* This is a comment */ "after";
     ');
   }
 
   #[Test]
   public function multiline_slash_asterisk() {
-    $this->assertParsed([new Literal('"test"', 5)], '
+    $this->assertParsed([new Scalar('"test"', 'string', 5)], '
       /* This is a comment
        * spanning multiple lines.
        */
@@ -88,7 +88,7 @@ class CommentTest extends ParseTest {
 
   #[Test]
   public function apidoc_comment_at_end_discarded() {
-    $this->assertParsed([new Literal('"test"', 2)], '
+    $this->assertParsed([new Scalar('"test"', 'string', 2)], '
       "test";  /** Discarded */
     ');
   }
@@ -120,7 +120,7 @@ class CommentTest extends ParseTest {
   #[Test]
   public function apidoc_comment_attached_to_next_constant() {
     $class= new ClassDeclaration([], new IsValue('\\T'), null, [], [], null, null, 2);
-    $class->declare(new Constant(['public'], 'FIXTURE', null, new Literal('1', 4), null, new Comment('/** @api */', 3), 4));
+    $class->declare(new Constant(['public'], 'FIXTURE', null, new Scalar('1', 'integer', 4), null, new Comment('/** @api */', 3), 4));
 
     $this->assertParsed([$class], '
       class T {

--- a/src/test/php/lang/ast/unittest/parse/ConditionalTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/ConditionalTest.class.php
@@ -1,7 +1,18 @@
 <?php namespace lang\ast\unittest\parse;
 
 use lang\ast\Errors;
-use lang\ast\nodes\{CaseLabel, IfStatement, InvokeExpression, Literal, MatchCondition, MatchExpression, ScopeExpression, SwitchStatement, Variable};
+use lang\ast\nodes\{
+  CaseLabel,
+  IfStatement,
+  InvokeExpression,
+  Literal,
+  MatchCondition,
+  MatchExpression,
+  Scalar,
+  ScopeExpression,
+  SwitchStatement,
+  Variable
+};
 use test\{Assert, Before, Expect, Test};
 
 class ConditionalTest extends ParseTest {
@@ -57,7 +68,7 @@ class ConditionalTest extends ParseTest {
 
   #[Test]
   public function switch_with_one_case() {
-    $cases= [new CaseLabel(new Literal('1', self::LINE), $this->blocks[1], self::LINE)];
+    $cases= [new CaseLabel(new Scalar('1', 'integer', self::LINE), $this->blocks[1], self::LINE)];
     $this->assertParsed(
       [new SwitchStatement(new Variable('condition', self::LINE), $cases, self::LINE)],
       'switch ($condition) { case 1: action1(); }'
@@ -85,8 +96,8 @@ class ConditionalTest extends ParseTest {
   #[Test]
   public function switch_with_two_cases() {
     $cases= [
-      new CaseLabel(new Literal('1', self::LINE), $this->blocks[1], self::LINE),
-      new CaseLabel(new Literal('2', self::LINE), $this->blocks[2], self::LINE)
+      new CaseLabel(new Scalar('1', 'integer', self::LINE), $this->blocks[1], self::LINE),
+      new CaseLabel(new Scalar('2', 'integer', self::LINE), $this->blocks[2], self::LINE)
     ];
     $this->assertParsed(
       [new SwitchStatement(new Variable('condition', self::LINE), $cases, self::LINE)],
@@ -114,7 +125,7 @@ class ConditionalTest extends ParseTest {
   #[Test]
   public function match_with_trailing_comma() {
     $cases= [
-      new MatchCondition([new Literal('1', self::LINE)], $this->blocks[1][0], self::LINE),
+      new MatchCondition([new Scalar('1', 'integer', self::LINE)], $this->blocks[1][0], self::LINE),
     ];
     $this->assertParsed(
       [new MatchExpression(new Variable('condition', self::LINE), $cases, null, self::LINE)],
@@ -125,8 +136,8 @@ class ConditionalTest extends ParseTest {
   #[Test]
   public function match_with_two_cases() {
     $cases= [
-      new MatchCondition([new Literal('1', self::LINE)], $this->blocks[1][0], self::LINE),
-      new MatchCondition([new Literal('2', self::LINE)], $this->blocks[2][0], self::LINE)
+      new MatchCondition([new Scalar('1', 'integer', self::LINE)], $this->blocks[1][0], self::LINE),
+      new MatchCondition([new Scalar('2', 'integer', self::LINE)], $this->blocks[2][0], self::LINE)
     ];
     $this->assertParsed(
       [new MatchExpression(new Variable('condition', self::LINE), $cases, null, self::LINE)],
@@ -137,7 +148,7 @@ class ConditionalTest extends ParseTest {
   #[Test]
   public function match_with_multi_expression_case_and_default() {
     $cases= [
-      new MatchCondition([new Literal('1', self::LINE), new Literal('2', self::LINE)], $this->blocks[1][0], self::LINE),
+      new MatchCondition([new Scalar('1', 'integer', self::LINE), new Scalar('2', 'integer', self::LINE)], $this->blocks[1][0], self::LINE),
     ];
     $this->assertParsed(
       [new MatchExpression(new Variable('condition', self::LINE), $cases, $this->blocks[2][0], self::LINE)],

--- a/src/test/php/lang/ast/unittest/parse/FunctionsTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/FunctionsTest.class.php
@@ -10,6 +10,7 @@ use lang\ast\nodes\{
   Literal,
   Parameter,
   ReturnStatement,
+  Scalar,
   Signature,
   Variable,
   YieldExpression,
@@ -50,7 +51,7 @@ class FunctionsTest extends ParseTest {
 
   #[Test]
   public function single_expression_function() {
-    $scope= new Literal('"A"', self::LINE);
+    $scope= new Scalar('"A"', 'string', self::LINE);
     $this->assertParsed(
       [new FunctionDeclaration('a', new Signature([], null, false, self::LINE), $scope, self::LINE)],
       'function a() => "A";'
@@ -176,7 +177,7 @@ class FunctionsTest extends ParseTest {
 
   #[Test]
   public function generator_with_value() {
-    $yield= new YieldExpression(null, new Literal('1', self::LINE), self::LINE);
+    $yield= new YieldExpression(null, new Scalar('1', 'integer', self::LINE), self::LINE);
     $this->assertParsed(
       [new FunctionDeclaration('a', new Signature([], null, false, self::LINE), new Block([$yield], self::LINE), self::LINE)],
       'function a() { yield 1; }'
@@ -185,7 +186,7 @@ class FunctionsTest extends ParseTest {
 
   #[Test]
   public function generator_with_key_and_value() {
-    $yield= new YieldExpression(new Literal('"number"', self::LINE), new Literal('1', self::LINE), self::LINE);
+    $yield= new YieldExpression(new Scalar('"number"', 'string', self::LINE), new Scalar('1', 'integer', self::LINE), self::LINE);
     $this->assertParsed(
       [new FunctionDeclaration('a', new Signature([], null, false, self::LINE), new Block([$yield], self::LINE), self::LINE)],
       'function a() { yield "number" => 1; }'
@@ -220,7 +221,7 @@ class FunctionsTest extends ParseTest {
     $yield= new Assignment(
       new Variable('value', self::LINE),
       '=',
-      new YieldExpression(null, new Braced(new Literal('1', self::LINE), self::LINE), self::LINE),
+      new YieldExpression(null, new Braced(new Scalar('1', 'integer', self::LINE), self::LINE), self::LINE),
       self::LINE
     );
     $this->assertParsed(
@@ -263,7 +264,7 @@ class FunctionsTest extends ParseTest {
     $yield= new Assignment(
       new Variable('value', self::LINE),
       '=',
-      new ArrayLiteral([[new YieldExpression(null, null, self::LINE), new Literal('1', self::LINE)]], self::LINE),
+      new ArrayLiteral([[new YieldExpression(null, null, self::LINE), new Scalar('1', 'integer', self::LINE)]], self::LINE),
       self::LINE
     );
     $this->assertParsed(

--- a/src/test/php/lang/ast/unittest/parse/InvokeTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/InvokeTest.class.php
@@ -10,6 +10,7 @@ use lang\ast\nodes\{
   ScopeExpression,
   Literal,
   Placeholder,
+  Scalar,
   Variable
 };
 use lang\ast\types\IsValue;
@@ -41,7 +42,7 @@ class InvokeTest extends ParseTest {
 
   #[Test]
   public function invoke_function_with_argument() {
-    $arguments= [new Literal('1', self::LINE)];
+    $arguments= [new Scalar('1', 'integer', self::LINE)];
     $this->assertParsed(
       [new InvokeExpression(new Literal('test', self::LINE), $arguments, self::LINE)],
       'test(1);'
@@ -50,7 +51,7 @@ class InvokeTest extends ParseTest {
 
   #[Test]
   public function invoke_function_with_arguments() {
-    $arguments= [new Literal('1', self::LINE), new Literal('2', self::LINE)];
+    $arguments= [new Scalar('1', 'integer', self::LINE), new Scalar('2', 'integer', self::LINE)];
     $this->assertParsed(
       [new InvokeExpression(new Literal('test', self::LINE), $arguments, self::LINE)],
       'test(1, 2);'
@@ -59,7 +60,7 @@ class InvokeTest extends ParseTest {
 
   #[Test]
   public function invoke_function_with_dangling_comma() {
-    $arguments= [new Literal('1', self::LINE), new Literal('2', self::LINE)];
+    $arguments= [new Scalar('1', 'integer', self::LINE), new Scalar('2', 'integer', self::LINE)];
     $this->assertParsed(
       [new InvokeExpression(new Literal('test', self::LINE), $arguments, self::LINE)],
       'test(1, 2, );'
@@ -68,7 +69,7 @@ class InvokeTest extends ParseTest {
 
   #[Test]
   public function invoke_function_with_positional_and_named_arguments() {
-    $arguments= [0 => new Literal('1', self::LINE), 'named' => new Literal('2', self::LINE)];
+    $arguments= [0 => new Scalar('1', 'integer', self::LINE), 'named' => new Scalar('2', 'integer', self::LINE)];
     $this->assertParsed(
       [new InvokeExpression(new Literal('test', self::LINE), $arguments, self::LINE)],
       'test(1, named: 2);'
@@ -125,7 +126,11 @@ class InvokeTest extends ParseTest {
     $this->assertParsed(
       [new CallableExpression(
         new Literal('str_replace', self::LINE),
-        [new Literal('"test"', self::LINE), new Literal('"ok"', self::LINE), Placeholder::$ARGUMENT],
+        [
+          new Scalar('"test"', 'string', self::LINE),
+          new Scalar('"ok"', 'string', self::LINE),
+          Placeholder::$ARGUMENT
+        ],
         self::LINE
       )],
       'str_replace("test", "ok", ?);'
@@ -137,7 +142,11 @@ class InvokeTest extends ParseTest {
     $this->assertParsed(
       [new CallableExpression(
         new Literal('str_replace', self::LINE),
-        [new Literal('"test"', self::LINE), new Literal('"ok"', self::LINE), 'subject' => Placeholder::$ARGUMENT],
+        [
+          new Scalar('"test"', 'string', self::LINE),
+          new Scalar('"ok"', 'string', self::LINE),
+          'subject' => Placeholder::$ARGUMENT,
+        ],
         self::LINE
       )],
       'str_replace("test", "ok", subject: ?);'

--- a/src/test/php/lang/ast/unittest/parse/LambdasTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/LambdasTest.class.php
@@ -1,6 +1,17 @@
 <?php namespace lang\ast\unittest\parse;
 
-use lang\ast\nodes\{BinaryExpression, Block, InvokeExpression, LambdaExpression, Literal, Parameter, ReturnStatement, Signature, Variable};
+use lang\ast\nodes\{
+  BinaryExpression,
+  Block,
+  InvokeExpression,
+  LambdaExpression,
+  Literal,
+  Parameter,
+  ReturnStatement,
+  Signature,
+  Scalar,
+  Variable
+};
 use test\{Assert, Before, Test};
 
 class LambdasTest extends ParseTest {
@@ -8,7 +19,12 @@ class LambdasTest extends ParseTest {
 
   #[Before]
   public function expression() {
-    $this->expression= new BinaryExpression(new Variable('a', self::LINE), '+', new Literal('1', self::LINE), self::LINE);
+    $this->expression= new BinaryExpression(
+      new Variable('a', self::LINE),
+      '+',
+      new Scalar('1', 'integer', self::LINE),
+      self::LINE
+    );
     $this->parameter= new Parameter('a', null, null, false, false, null, null, null, self::LINE);
   }
 

--- a/src/test/php/lang/ast/unittest/parse/LiteralsTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/LiteralsTest.class.php
@@ -1,28 +1,28 @@
 <?php namespace lang\ast\unittest\parse;
 
-use lang\ast\nodes\{ArrayLiteral, Literal};
+use lang\ast\nodes\{ArrayLiteral, Literal, Scalar};
 use test\{Assert, Test, Values};
 
 class LiteralsTest extends ParseTest {
 
   #[Test, Values(['0', '1'])]
   public function integer($input) {
-    $this->assertParsed([new Literal($input, self::LINE)], $input.';');
+    $this->assertParsed([new Scalar($input, 'integer', self::LINE)], $input.';');
   }
 
   #[Test, Values(['0x00', '0x01', '0xFF', '0xff'])]
   public function hexadecimal($input) {
-    $this->assertParsed([new Literal($input, self::LINE)], $input.';');
+    $this->assertParsed([new Scalar($input, 'integer', self::LINE)], $input.';');
   }
 
   #[Test, Values(['00', '01', '010', '0777', '0o16', '0O16'])]
   public function octal($input) {
-    $this->assertParsed([new Literal($input, self::LINE)], $input.';');
+    $this->assertParsed([new Scalar($input, 'integer', self::LINE)], $input.';');
   }
 
   #[Test, Values(['1.0', '1.5'])]
   public function decimal($input) {
-    $this->assertParsed([new Literal($input, self::LINE)], $input.';');
+    $this->assertParsed([new Scalar($input, 'decimal', self::LINE)], $input.';');
   }
 
   #[Test]
@@ -42,17 +42,17 @@ class LiteralsTest extends ParseTest {
 
   #[Test]
   public function empty_string() {
-    $this->assertParsed([new Literal('""', self::LINE)], '"";');
+    $this->assertParsed([new Scalar('""', 'string', self::LINE)], '"";');
   }
 
   #[Test]
   public function non_empty_string() {
-    $this->assertParsed([new Literal('"Test"', self::LINE)], '"Test";');
+    $this->assertParsed([new Scalar('"Test"', 'string', self::LINE)], '"Test";');
   }
 
   #[Test]
   public function exec_statement() {
-    $this->assertParsed([new Literal('`ls -al`', self::LINE)], '`ls -al`;');
+    $this->assertParsed([new Scalar('`ls -al`', 'string', self::LINE)], '`ls -al`;');
   }
 
   #[Test, Values(['[];', ['array();']])]
@@ -63,27 +63,27 @@ class LiteralsTest extends ParseTest {
   #[Test, Values(['[1, 2];', ['array(1, 2);']])]
   public function int_array($declaration) {
     $pairs= [
-      [null, new Literal('1', self::LINE)],
-      [null, new Literal('2', self::LINE)]
+      [null, new Scalar('1', 'integer', self::LINE)],
+      [null, new Scalar('2', 'integer', self::LINE)]
     ];
     $this->assertParsed([new ArrayLiteral($pairs, self::LINE)], $declaration);
   }
 
   #[Test, Values(['["key" => "value"];', ['array("key" => "value");']])]
   public function key_value_map($declaration) {
-    $pair= [new Literal('"key"', self::LINE), new Literal('"value"', self::LINE)];
+    $pair= [new Scalar('"key"', 'string', self::LINE), new Scalar('"value"', 'string', self::LINE)];
     $this->assertParsed([new ArrayLiteral([$pair], self::LINE)], $declaration);
   }
 
   #[Test, Values(['[1, ];', 'array(1, );'])]
   public function dangling_comma_in_array($declaration) {
-    $pair= [null, new Literal('1', self::LINE)];
+    $pair= [null, new Scalar('1', 'integer', self::LINE)];
     $this->assertParsed([new ArrayLiteral([$pair], self::LINE)], $declaration);
   }
 
   #[Test, Values(['["key" => "value", ];', 'array("key" => "value", );'])]
   public function dangling_comma_in_key_value_map($declaration) {
-    $pair= [new Literal('"key"', self::LINE), new Literal('"value"', self::LINE)];
+    $pair= [new Scalar('"key"', 'string', self::LINE), new Scalar('"value"', 'string', self::LINE)];
     $this->assertParsed([new ArrayLiteral([$pair], self::LINE)], $declaration);
   }
 
@@ -97,7 +97,7 @@ class LiteralsTest extends ParseTest {
       "Line 4\n".
       "EOD"
     );
-    $this->assertParsed([new Literal($nowdoc, self::LINE)], $nowdoc.';');
+    $this->assertParsed([new Scalar($nowdoc, 'heredoc', self::LINE)], $nowdoc.';');
   }
 
   #[Test]
@@ -110,7 +110,7 @@ class LiteralsTest extends ParseTest {
       "  Line 4\n".
       "  EOD"
     );
-    $this->assertParsed([new Literal($nowdoc, self::LINE)], $nowdoc.';');
+    $this->assertParsed([new Scalar($nowdoc, 'heredoc', self::LINE)], $nowdoc.';');
   }
 
   #[Test]
@@ -121,7 +121,7 @@ class LiteralsTest extends ParseTest {
       "</html>'"
     );
     $this->assertParsed(
-      [new Literal($string, self::LINE), new Literal('null', self::LINE + 3)],
+      [new Scalar($string, 'string', self::LINE), new Literal('null', self::LINE + 3)],
       $string.";\nnull;"
     );
   }
@@ -134,7 +134,7 @@ class LiteralsTest extends ParseTest {
       "  EOD"
     );
     $this->assertParsed(
-      [new Literal($nowdoc, self::LINE), new Literal('null', self::LINE + 3)],
+      [new Scalar($nowdoc, 'heredoc', self::LINE), new Literal('null', self::LINE + 3)],
       $nowdoc.";\nnull;"
     );
   }

--- a/src/test/php/lang/ast/unittest/parse/LoopsTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/LoopsTest.class.php
@@ -12,6 +12,7 @@ use lang\ast\nodes\{
   InvokeExpression,
   Label,
   Literal,
+  Scalar,
   UnaryExpression,
   Variable,
   WhileLoop
@@ -72,8 +73,8 @@ class LoopsTest extends ParseTest {
   public function for_loop() {
     $this->assertParsed(
       [new ForLoop(
-        [new Assignment(new Variable('i', self::LINE), '=', new Literal('0', self::LINE), self::LINE)],
-        [new BinaryExpression(new Variable('i', self::LINE), '<', new Literal('10', self::LINE), self::LINE)],
+        [new Assignment(new Variable('i', self::LINE), '=', new Scalar('0', 'integer', self::LINE), self::LINE)],
+        [new BinaryExpression(new Variable('i', self::LINE), '<', new Scalar('10', 'integer', self::LINE), self::LINE)],
         [new UnaryExpression('suffix', new Variable('i', self::LINE), '++', self::LINE)],
         [$this->loop],
         self::LINE
@@ -141,7 +142,7 @@ class LoopsTest extends ParseTest {
   #[Test]
   public function break_statement_with_level() {
     $this->assertParsed(
-      [new BreakStatement(new Literal('2', self::LINE), self::LINE)],
+      [new BreakStatement(new Scalar('2', 'integer', self::LINE), self::LINE)],
       'break 2;'
     );
   }
@@ -157,7 +158,7 @@ class LoopsTest extends ParseTest {
   #[Test]
   public function continue_statement_with_level() {
     $this->assertParsed(
-      [new ContinueStatement(new Literal('2', self::LINE), self::LINE)],
+      [new ContinueStatement(new Scalar('2', 'integer', self::LINE), self::LINE)],
       'continue 2;'
     );
   }

--- a/src/test/php/lang/ast/unittest/parse/MatchExpressionTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/MatchExpressionTest.class.php
@@ -8,7 +8,8 @@ use lang\ast\nodes\{
   Block,
   ReturnStatement,
   ThrowExpression,
-  NewExpression
+  NewExpression,
+  Scalar
 };
 use lang\ast\types\IsValue;
 use test\{Assert, Test};
@@ -26,8 +27,8 @@ class MatchExpressionTest extends ParseTest {
   #[Test]
   public function match() {
     $cases= [
-      new MatchCondition([new Literal('0', self::LINE)], new Literal('true', self::LINE), self::LINE),
-      new MatchCondition([new Literal('1', self::LINE)], new Literal('false', self::LINE), self::LINE)
+      new MatchCondition([new Scalar('0', 'integer', self::LINE)], new Literal('true', self::LINE), self::LINE),
+      new MatchCondition([new Scalar('1', 'integer', self::LINE)], new Literal('false', self::LINE), self::LINE)
     ];
     $this->assertParsed(
       [new MatchExpression(new Variable('arg', self::LINE), $cases, null, self::LINE)],
@@ -47,7 +48,7 @@ class MatchExpressionTest extends ParseTest {
   #[Test]
   public function match_with_case_block() {
     $cases= [new MatchCondition(
-      [new Literal('0', self::LINE)],
+      [new Scalar('0', 'integer', self::LINE)],
       new Block([new ReturnStatement(new Literal('false', self::LINE), self::LINE)], self::LINE),
       self::LINE
     )];
@@ -77,8 +78,8 @@ class MatchExpressionTest extends ParseTest {
   #[Test]
   public function match_with_trailing_comma() {
     $cases= [
-      new MatchCondition([new Literal('0', self::LINE)], new Literal('true', self::LINE), self::LINE),
-      new MatchCondition([new Literal('1', self::LINE)], new Literal('false', self::LINE), self::LINE)
+      new MatchCondition([new Scalar('0', 'integer', self::LINE)], new Literal('true', self::LINE), self::LINE),
+      new MatchCondition([new Scalar('1', 'integer', self::LINE)], new Literal('false', self::LINE), self::LINE)
     ];
     $this->assertParsed(
       [new MatchExpression(new Variable('arg', self::LINE), $cases, null, self::LINE)],
@@ -89,8 +90,16 @@ class MatchExpressionTest extends ParseTest {
   #[Test]
   public function match_with_multiple_cases() {
     $cases= [
-      new MatchCondition([new Literal('0', self::LINE), new Literal('1', self::LINE)], new Literal('true', self::LINE), self::LINE),
-      new MatchCondition([new Literal('2', self::LINE), new Literal('3', self::LINE)], new Literal('false', self::LINE), self::LINE)
+      new MatchCondition(
+        [new Scalar('0', 'integer', self::LINE), new Scalar('1', 'integer', self::LINE)],
+        new Literal('true', self::LINE),
+        self::LINE
+      ),
+      new MatchCondition(
+        [new Scalar('2', 'integer', self::LINE), new Scalar('3', 'integer', self::LINE)],
+        new Literal('false', self::LINE),
+        self::LINE
+      )
     ];
     $this->assertParsed(
       [new MatchExpression(new Variable('arg', self::LINE), $cases, null, self::LINE)],
@@ -101,8 +110,8 @@ class MatchExpressionTest extends ParseTest {
   #[Test]
   public function match_with_default() {
     $cases= [
-      new MatchCondition([new Literal('0', self::LINE)], new Literal('true', self::LINE), self::LINE),
-      new MatchCondition([new Literal('1', self::LINE)], new Literal('false', self::LINE), self::LINE)
+      new MatchCondition([new Scalar('0', 'integer', self::LINE)], new Literal('true', self::LINE), self::LINE),
+      new MatchCondition([new Scalar('1', 'integer', self::LINE)], new Literal('false', self::LINE), self::LINE)
     ];
     $this->assertParsed(
       [new MatchExpression(new Variable('arg', self::LINE), $cases, new Literal('null', self::LINE), self::LINE)],

--- a/src/test/php/lang/ast/unittest/parse/MembersTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/MembersTest.class.php
@@ -14,6 +14,7 @@ use lang\ast\nodes\{
   Method,
   Property,
   ReturnStatement,
+  Scalar,
   ScopeExpression,
   Signature,
   Variable,
@@ -95,7 +96,7 @@ class MembersTest extends ParseTest {
 
   #[Test]
   public function single_expression_method() {
-    $scope= new Literal('"A"', self::LINE);
+    $scope= new Scalar('"A"', 'string', self::LINE);
     $class= new ClassDeclaration([], new IsValue('\\A'), null, [], [], null, null, self::LINE);
     $class->declare(new Method(['private'], 'a', new Signature([], null, false, self::LINE), $scope, null, null, self::LINE));
 
@@ -105,7 +106,7 @@ class MembersTest extends ParseTest {
   #[Test]
   public function class_constant() {
     $class= new ClassDeclaration([], new IsValue('\\A'), null, [], [], null, null, self::LINE);
-    $class->declare(new Constant([], 'T', null, new Literal('1', self::LINE), null, null, self::LINE));
+    $class->declare(new Constant([], 'T', null, new Scalar('1', 'integer', self::LINE), null, null, self::LINE));
 
     $this->assertParsed([$class], 'class A { const T = 1; }');
   }
@@ -113,8 +114,8 @@ class MembersTest extends ParseTest {
   #[Test]
   public function class_constants() {
     $class= new ClassDeclaration([], new IsValue('\\A'), null, [], [], null, null, self::LINE);
-    $class->declare(new Constant([], 'T', null, new Literal('1', self::LINE), null, null, self::LINE));
-    $class->declare(new Constant([], 'S', null, new Literal('2', self::LINE), null, null, self::LINE));
+    $class->declare(new Constant([], 'T', null, new Scalar('1', 'integer', self::LINE), null, null, self::LINE));
+    $class->declare(new Constant([], 'S', null, new Scalar('2', 'integer', self::LINE), null, null, self::LINE));
 
     $this->assertParsed([$class], 'class A { const T = 1, S = 2; }');
   }
@@ -122,7 +123,7 @@ class MembersTest extends ParseTest {
   #[Test]
   public function private_class_constant() {
     $class= new ClassDeclaration([], new IsValue('\\A'), null, [], [], null, null, self::LINE);
-    $class->declare(new Constant(['private'], 'T', null, new Literal('1', self::LINE), null, null, self::LINE));
+    $class->declare(new Constant(['private'], 'T', null, new Scalar('1', 'integer', self::LINE), null, null, self::LINE));
 
     $this->assertParsed([$class], 'class A { private const T = 1; }');
   }
@@ -155,7 +156,10 @@ class MembersTest extends ParseTest {
 
   #[Test]
   public function method_with_annotations() {
-    $annotations= new Annotations(['Test' => [], 'Ignore' => [new Literal('"Not implemented"', self::LINE)]], self::LINE);
+    $annotations= new Annotations([
+      'Test'   => [],
+      'Ignore' => [new Scalar('"Not implemented"', 'string', self::LINE)],
+    ], self::LINE);
     $class= new ClassDeclaration([], new IsValue('\\A'), null, [], [], null, null, self::LINE);
     $class->declare(new Method(['public'], 'a', new Signature([], null, false, self::LINE), $this->empty, $annotations, null, self::LINE));
 
@@ -166,7 +170,7 @@ class MembersTest extends ParseTest {
   public function property_with_get_and_set_hooks() {
     $class= new ClassDeclaration([], new IsValue('\\A'), null, [], [], null, null, self::LINE);
     $prop= new Property(['public'], 'a', null, null, null, null, self::LINE);
-    $return= new ReturnStatement(new Literal('"Hello"', self::LINE), self::LINE);
+    $return= new ReturnStatement(new Scalar('"Hello"', 'string', self::LINE), self::LINE);
     $parameter= new Parameter('value', null, null, false, false, null, null, null, self::LINE);
     $prop->hooks['get']= new Hook([], 'get', new Block([$return], self::LINE), false, null, self::LINE);
     $prop->hooks['set']= new Hook([], 'set', new Block([], self::LINE), false, $parameter, self::LINE);
@@ -179,7 +183,7 @@ class MembersTest extends ParseTest {
   public function property_with_short_get_hook() {
     $class= new ClassDeclaration([], new IsValue('\\A'), null, [], [], null, null, self::LINE);
     $prop= new Property(['public'], 'a', null, null, null, null, self::LINE);
-    $prop->hooks['get']= new Hook([], 'get', new Literal('"Hello"', self::LINE), false, null, self::LINE);
+    $prop->hooks['get']= new Hook([], 'get', new Scalar('"Hello"', 'string' ,self::LINE), false, null, self::LINE);
     $class->declare($prop);
 
     $this->assertParsed([$class], 'class A { public $a { get => "Hello"; } }');
@@ -189,7 +193,7 @@ class MembersTest extends ParseTest {
   public function property_with_abbreviated_get_hook() {
     $class= new ClassDeclaration([], new IsValue('\\A'), null, [], [], null, null, self::LINE);
     $prop= new Property(['public'], 'a', null, null, null, null, self::LINE);
-    $prop->hooks['get']= new Hook([], 'get', new Literal('"Hello"', self::LINE), false, null, self::LINE);
+    $prop->hooks['get']= new Hook([], 'get', new Scalar('"Hello"', 'string' ,self::LINE), false, null, self::LINE);
     $class->declare($prop);
 
     $this->assertParsed([$class], 'class A { public $a => "Hello"; }');
@@ -333,7 +337,7 @@ class MembersTest extends ParseTest {
     $this->assertParsed(
       [new InvokeExpression(
         new InstanceExpression(new Variable('a', self::LINE), new Literal('member', self::LINE), self::LINE),
-        [new Literal('1', self::LINE)],
+        [new Scalar('1', 'integer', self::LINE)],
         self::LINE
       )],
       '$a->member(1);'
@@ -345,7 +349,7 @@ class MembersTest extends ParseTest {
     $this->assertParsed(
       [new ScopeExpression(
         '\\A',
-        new InvokeExpression(new Literal('member', self::LINE), [new Literal('1', self::LINE)], self::LINE),
+        new InvokeExpression(new Literal('member', self::LINE), [new Scalar('1', 'integer', self::LINE)], self::LINE),
         self::LINE
       )],
       'A::member(1);'
@@ -363,7 +367,7 @@ class MembersTest extends ParseTest {
   #[Test]
   public function typed_property_with_value() {
     $class= new ClassDeclaration([], new IsValue('\\A'), null, [], [], null, null, self::LINE);
-    $class->declare(new Property(['private'], 'a', new Type('string'), new Literal('"test"', self::LINE), null, null, self::LINE));
+    $class->declare(new Property(['private'], 'a', new Type('string'), new Scalar('"test"', 'string', self::LINE), null, null, self::LINE));
 
     $this->assertParsed([$class], 'class A { private string $a = "test"; }');
   }
@@ -389,7 +393,7 @@ class MembersTest extends ParseTest {
   #[Test]
   public function typed_constant() {
     $class= new ClassDeclaration([], new IsValue('\\A'), null, [], [], null, null, self::LINE);
-    $class->declare(new Constant([], 'T', new Type('int'), new Literal('1', self::LINE), null, null, self::LINE));
+    $class->declare(new Constant([], 'T', new Type('int'), new Scalar('1', 'integer', self::LINE), null, null, self::LINE));
 
     $this->assertParsed([$class], 'class A { const int T = 1; }');
   }
@@ -397,9 +401,9 @@ class MembersTest extends ParseTest {
   #[Test]
   public function typed_constants() {
     $class= new ClassDeclaration([], new IsValue('\\A'), null, [], [], null, null, self::LINE);
-    $class->declare(new Constant([], 'T', new Type('int'), new Literal('1', self::LINE), null, null, self::LINE));
-    $class->declare(new Constant([], 'S', new Type('int'), new Literal('2', self::LINE), null, null, self::LINE));
-    $class->declare(new Constant([], 'I', new Type('string'), new Literal('"i"', self::LINE), null, null, self::LINE));
+    $class->declare(new Constant([], 'T', new Type('int'), new Scalar('1', 'integer', self::LINE), null, null, self::LINE));
+    $class->declare(new Constant([], 'S', new Type('int'), new Scalar('2', 'integer', self::LINE), null, null, self::LINE));
+    $class->declare(new Constant([], 'I', new Type('string'), new Scalar('"i"', 'string', self::LINE), null, null, self::LINE));
 
     $this->assertParsed([$class], 'class A { const int T = 1, S = 2, string I = "i"; }');
   }

--- a/src/test/php/lang/ast/unittest/parse/OperatorTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/OperatorTest.class.php
@@ -14,6 +14,7 @@ use lang\ast\nodes\{
   NewClassExpression,
   NewExpression,
   OffsetExpression,
+  Scalar,
   ScopeExpression,
   TernaryExpression,
   UnaryExpression,
@@ -35,7 +36,7 @@ class OperatorTest extends ParseTest {
   #[Test]
   public function ternary() {
     $this->assertParsed(
-      [new TernaryExpression(new Variable('a', self::LINE), new Literal('1', self::LINE), new Literal('2', self::LINE), self::LINE)],
+      [new TernaryExpression(new Variable('a', self::LINE), new Scalar('1', 'integer', self::LINE), new Scalar('2', 'integer', self::LINE), self::LINE)],
       '$a ? 1 : 2;'
     );
   }
@@ -81,7 +82,7 @@ class OperatorTest extends ParseTest {
 
   #[Test]
   public function assignment_to_offset() {
-    $target= new OffsetExpression(new Variable('a', self::LINE), new Literal('0', self::LINE), self::LINE);
+    $target= new OffsetExpression(new Variable('a', self::LINE), new Scalar('0', 'integer', self::LINE), self::LINE);
     $this->assertParsed(
       [new Assignment($target, '=', new Variable('b', self::LINE), self::LINE)],
       '$a[0]= $b;'
@@ -101,8 +102,8 @@ class OperatorTest extends ParseTest {
   public function comparison_to_assignment() {
     $this->assertParsed(
       [new BinaryExpression(
-        new Literal('1', self::LINE), '===', new Braced(
-          new Assignment(new Variable('a', self::LINE), '=', new Literal('1', self::LINE), self::LINE),
+        new Scalar('1', 'integer', self::LINE), '===', new Braced(
+          new Assignment(new Variable('a', self::LINE), '=', new Scalar('1', 'integer', self::LINE), self::LINE),
           self::LINE
         ),
         self::LINE
@@ -130,7 +131,7 @@ class OperatorTest extends ParseTest {
 
   #[Test]
   public function clone_with() {
-    $with= [[new Literal('"id"', self::LINE), new Literal('6100', self::LINE)]];
+    $with= [[new Scalar('"id"', 'string', self::LINE), new Scalar('6100', 'integer', self::LINE)]];
     $this->assertParsed(
       [new CloneExpression([new Variable('a', self::LINE), new ArrayLiteral($with, self::LINE)], self::LINE)],
       'clone($a, ["id" => 6100]);'
@@ -241,7 +242,7 @@ class OperatorTest extends ParseTest {
       [new BinaryExpression(
         new InstanceExpression(new Variable('this', self::LINE), new Literal('a', self::LINE), self::LINE),
         '.',
-        new Literal('"test"', self::LINE),
+        new Scalar('"test"', 'string', self::LINE),
         self::LINE
       )],
       '$this->a."test";'
@@ -267,7 +268,7 @@ class OperatorTest extends ParseTest {
       [new BinaryExpression(
         new ScopeExpression('self', new Literal('class', self::LINE), self::LINE),
         '.',
-        new Literal('"test"', self::LINE),
+        new Scalar('"test"', 'string', self::LINE),
         self::LINE
       )],
       'self::class."test";'
@@ -316,7 +317,7 @@ class OperatorTest extends ParseTest {
   public function precedence_of_prefix($operator) {
     $this->assertParsed(
       [new BinaryExpression(
-        new UnaryExpression('prefix', new Literal('2', self::LINE), $operator, self::LINE),
+        new UnaryExpression('prefix', new Scalar('2', 'integer', self::LINE), $operator, self::LINE),
         '===',
         new Variable('value', self::LINE),
         self::LINE
@@ -343,7 +344,7 @@ class OperatorTest extends ParseTest {
     $this->assertParsed(
       [new UnaryExpression(
         'prefix',
-        new OffsetExpression(new Variable('a', self::LINE), new Literal('0', self::LINE), self::LINE),
+        new OffsetExpression(new Variable('a', self::LINE), new Scalar('0', 'integer', self::LINE), self::LINE),
         '!',
         self::LINE
       )],
@@ -355,8 +356,8 @@ class OperatorTest extends ParseTest {
   public function multiple_semicolons() {
     $this->assertParsed(
       [
-        new Assignment(new Variable('a', self::LINE), '=', new Literal('1', self::LINE), self::LINE),
-        new Assignment(new Variable('b', self::LINE), '=', new Literal('2', self::LINE), self::LINE)
+        new Assignment(new Variable('a', self::LINE), '=', new Scalar('1', 'integer', self::LINE), self::LINE),
+        new Assignment(new Variable('b', self::LINE), '=', new Scalar('2', 'integer', self::LINE), self::LINE)
       ],
       ';; $a= 1 ;;; $b= 2;'
     );

--- a/src/test/php/lang/ast/unittest/parse/StartTokensTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/StartTokensTest.class.php
@@ -1,7 +1,7 @@
 <?php namespace lang\ast\unittest\parse;
 
 use lang\ast\Errors;
-use lang\ast\nodes\{Directives, Literal, NamespaceDeclaration};
+use lang\ast\nodes\{Directives, NamespaceDeclaration, Scalar};
 use test\{Assert, Expect, Test};
 
 class StartTokensTest extends ParseTest {
@@ -16,7 +16,7 @@ class StartTokensTest extends ParseTest {
 
   #[Test]
   public function declare() {
-    $declare= ['strict_types' => new Literal('1', self::LINE)];
+    $declare= ['strict_types' => new Scalar('1', 'integer', self::LINE)];
     $this->assertParsed(
       [new Directives($declare, self::LINE)],
       '<?php declare(strict_types = 1);'
@@ -25,7 +25,10 @@ class StartTokensTest extends ParseTest {
 
   #[Test]
   public function declare_with_multiple() {
-    $declare= ['strict_types' => new Literal('1', self::LINE), 'encoding' => new Literal('"UTF-8"', self::LINE)];
+    $declare= [
+      'strict_types' => new Scalar('1', 'integer', self::LINE),
+      'encoding'     => new Scalar('"UTF-8"', 'string', self::LINE),
+    ];
     $this->assertParsed(
       [new Directives($declare, self::LINE)],
       '<?php declare(strict_types = 1, encoding = "UTF-8");'

--- a/src/test/php/lang/ast/unittest/parse/TypesTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/TypesTest.class.php
@@ -9,7 +9,7 @@ use lang\ast\nodes\{
   NamespaceDeclaration,
   TraitDeclaration,
   UseExpression,
-  Literal
+  Scalar
 };
 use lang\ast\types\IsValue;
 use test\{Assert, Expect, Test};
@@ -123,8 +123,8 @@ class TypesTest extends ParseTest {
   #[Test]
   public function backed_enum_with_cases() {
     $enum= new EnumDeclaration([], new IsValue('\\A'), 'int', [], [], null, null, self::LINE);
-    $enum->declare(new EnumCase('ONE', new Literal('1', self::LINE), null, null, self::LINE));
-    $enum->declare(new EnumCase('TWO', new Literal('2', self::LINE), null, null, self::LINE));
+    $enum->declare(new EnumCase('ONE', new Scalar('1', 'integer', self::LINE), null, null, self::LINE));
+    $enum->declare(new EnumCase('TWO', new Scalar('2', 'integer', self::LINE), null, null, self::LINE));
     $this->assertParsed([$enum], 'enum A: int { case ONE = 1; case TWO = 2; }');
   }
 

--- a/src/test/php/lang/ast/unittest/parse/VariablesTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/VariablesTest.class.php
@@ -1,6 +1,6 @@
 <?php namespace lang\ast\unittest\parse;
 
-use lang\ast\nodes\{Expression, Literal, OffsetExpression, StaticLocals, Variable};
+use lang\ast\nodes\{Expression, OffsetExpression, Scalar, StaticLocals, Variable};
 use test\{Assert, Test, Values};
 
 class VariablesTest extends ParseTest {
@@ -64,7 +64,7 @@ class VariablesTest extends ParseTest {
   #[Test]
   public function static_variable_with_initialization() {
     $this->assertParsed(
-      [new StaticLocals(['id' => new Literal('0', self::LINE)], self::LINE)],
+      [new StaticLocals(['id' => new Scalar('0', 'integer', self::LINE)], self::LINE)],
       'static $id= 0;'
     );
   }
@@ -72,7 +72,7 @@ class VariablesTest extends ParseTest {
   #[Test]
   public function array_offset() {
     $this->assertParsed(
-      [new OffsetExpression(new Variable('a', self::LINE), new Literal('0', self::LINE), self::LINE)],
+      [new OffsetExpression(new Variable('a', self::LINE), new Scalar('0', 'integer', self::LINE), self::LINE)],
       '$a[0];'
     );
   }


### PR DESCRIPTION
These changes are necessary in the compiler:

* emitString(), emitHeredoc(), emitInteger(), emitDecimal() implementations
* Checking for `instanceof Scalar`  in *isConstant()* and *EmulatePipelines* 

These changes can be made in reflection to optimize:

* string(), heredoc(), integer() and decimal() methods in `lang.meta.SyntaxTree`